### PR TITLE
splitting out mobile menu transition properties as autoprefixer cause…

### DIFF
--- a/opentech/static_src/src/sass/layout/_header.scss
+++ b/opentech/static_src/src/sass/layout/_header.scss
@@ -72,7 +72,9 @@
             background: $color--dark-grey;
             opacity: 0;
             transform: translate3d(0, -100%, 0);
-            transition: opacity, transform, $transition;
+            transition-duration: 0.25s;
+            transition-property: transform, opacity;
+            transition-timing-function: cubic-bezier(0.65, 0.05, 0.36, 1);
 
             &.is-visible {
                 opacity: 1;


### PR DESCRIPTION
…s the transition to break when transition shorthand is used