### PR TITLE
OAuth tweaks

### DIFF
--- a/opentech/apply/users/middleware.py
+++ b/opentech/apply/users/middleware.py
@@ -1,0 +1,12 @@
+from social_core.exceptions import AuthForbidden
+from social_django.middleware import SocialAuthExceptionMiddleware as _SocialAuthExceptionMiddleware
+
+class SocialAuthExceptionMiddleware(_SocialAuthExceptionMiddleware):
+    """
+    Wrapper around SocialAuthExceptionMiddleware to customise messages
+    """
+    def get_message(self, request, exception):
+        if isinstance(exception, AuthForbidden):
+            return 'Your credentials are not allowed'
+
+        super().get_message(request, exception)

--- a/opentech/apply/users/middleware.py
+++ b/opentech/apply/users/middleware.py
@@ -8,6 +8,6 @@ class SocialAuthExceptionMiddleware(_SocialAuthExceptionMiddleware):
     """
     def get_message(self, request, exception):
         if isinstance(exception, AuthForbidden):
-            return 'Your credentials are not allowed'
+            return 'Your credentials are not recognised.'
 
         super().get_message(request, exception)

--- a/opentech/apply/users/middleware.py
+++ b/opentech/apply/users/middleware.py
@@ -1,6 +1,7 @@
 from social_core.exceptions import AuthForbidden
 from social_django.middleware import SocialAuthExceptionMiddleware as _SocialAuthExceptionMiddleware
 
+
 class SocialAuthExceptionMiddleware(_SocialAuthExceptionMiddleware):
     """
     Wrapper around SocialAuthExceptionMiddleware to customise messages

--- a/opentech/apply/users/templates/users/account.html
+++ b/opentech/apply/users/templates/users/account.html
@@ -10,8 +10,11 @@
     <a href="{% url 'users:password_change' %}">{% trans "Change password" %}</a>
 {% endif %}
 
+{# Remove the comment block tags below when such need arises. e.g. adding new providers #}
+{% comment %}
 {% can_use_oauth as show_oauth_link %}
 {% if show_oauth_link %}
     <a href="{% url 'users:oauth' %}">{% trans "Manage OAuth" %}</a>
 {% endif %}
+{% endcomment %}
 {% endblock %}

--- a/opentech/apply/users/templates/users/login.html
+++ b/opentech/apply/users/templates/users/login.html
@@ -4,6 +4,15 @@
 
 {% block content %}
   <h2>Login</h2>
+
+  {% if messages %}
+  <ul class="messages">
+    {% for message in messages %}
+    <li{% if message.tags %} class="{{ message.tags }}" {% endif %}>{{ message }}</li>
+      {% endfor %}
+  </ul>
+  {% endif %}
+
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}

--- a/opentech/apply/users/tests/test_oauth_access.py
+++ b/opentech/apply/users/tests/test_oauth_access.py
@@ -28,12 +28,12 @@ class TestOAuthAccess(TestCase):
         response = self.client.get(reverse('users:oauth'), follow=True)
         self.assertEqual(response.status_code, 403)
 
-    @override_settings(SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS=['email.com'])
-    def test_oauth_whitelisted_user_can_see_link_to_oauth_settings_page(self):
-        self.login()
+    # @override_settings(SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS=['email.com'])
+    # def test_oauth_whitelisted_user_can_see_link_to_oauth_settings_page(self):
+    #     self.login()
 
-        response = self.client.get(reverse('users:account'), follow=True)
-        self.assertContains(response, 'Manage OAuth')
+    #     response = self.client.get(reverse('users:account'), follow=True)
+    #     self.assertContains(response, 'Manage OAuth')
 
     @override_settings(SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS=['email.com'])
     def test_oauth_whitelisted_user_can_access_oauth_settings_page(self):

--- a/opentech/apply/users/tests/test_oauth_access.py
+++ b/opentech/apply/users/tests/test_oauth_access.py
@@ -28,12 +28,12 @@ class TestOAuthAccess(TestCase):
         response = self.client.get(reverse('users:oauth'), follow=True)
         self.assertEqual(response.status_code, 403)
 
-    # @override_settings(SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS=['email.com'])
-    # def test_oauth_whitelisted_user_can_see_link_to_oauth_settings_page(self):
-    #     self.login()
+    @override_settings(SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS=['email.com'])
+    def test_oauth_whitelisted_user_can_see_link_to_oauth_settings_page(self):
+        self.login()
 
-    #     response = self.client.get(reverse('users:account'), follow=True)
-    #     self.assertContains(response, 'Manage OAuth')
+        response = self.client.get(reverse('users:account'), follow=True)
+        self.assertNotContains(response, 'Manage OAuth')
 
     @override_settings(SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS=['email.com'])
     def test_oauth_whitelisted_user_can_access_oauth_settings_page(self):

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -75,7 +75,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'social_django.middleware.SocialAuthExceptionMiddleware',
+    'opentech.apply.users.middleware.SocialAuthExceptionMiddleware',
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',


### PR DESCRIPTION
Displays error messages on the login form (including those from django social auth) and hides "Manage OAuth" for the time being