### PR TITLE
Feature/28 fix date default for fe

### DIFF
--- a/opentech/apply/stream_forms/blocks.py
+++ b/opentech/apply/stream_forms/blocks.py
@@ -158,6 +158,7 @@ class DatePickerInput(forms.DateInput):
             'data-date-format': 'yyyy-mm-dd',
         })
         kwargs['attrs'] = attrs
+        kwargs['format'] = '%Y-%m-%d'
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
It _should_ have been doing this anyway.  Perhaps it was trying to localise to US under the hood.

@chris-lawton There is a broader question of what date format we should be using. I'm guessing YYYY-MM-DD is the least likely to cause confusion generally, but we should probably discuss. 