### PR TITLE
Add a view and form for the fund chooser page

### DIFF
--- a/opentech/apply/funds/admin.py
+++ b/opentech/apply/funds/admin.py
@@ -1,10 +1,33 @@
+from django import forms
 from django.urls import reverse
+from django.utils.translation import ugettext as _
 
-from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup
+from wagtail.contrib.modeladmin.forms import ParentChooserForm
 from wagtail.contrib.modeladmin.helpers import PageButtonHelper
+from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup
+from wagtail.contrib.modeladmin.views import ChooseParentView
+from wagtail.wagtailcore.models import Page
 
 from .models import ApplicationForm, FundType, Round
 from opentech.apply.categories.admin import CategoryAdmin
+
+
+class FundChooserForm(ParentChooserForm):
+    """Changes the default chooser to be fund orientated """
+    parent_page = forms.ModelChoiceField(
+        label=_('Fund'),
+        required=True,
+        empty_label=None,
+        queryset=Page.objects.none(),
+        widget=forms.RadioSelect(),
+    )
+
+
+class RoundFundChooserView(ChooseParentView):
+    def get_form(self, request):
+        parents = self.permission_helper.get_valid_parent_pages(request.user)
+        return FundChooserForm(parents, request.POST or None)
+
 
 
 class ButtonsWithPreview(PageButtonHelper):
@@ -30,6 +53,8 @@ class ButtonsWithPreview(PageButtonHelper):
 
 class RoundAdmin(ModelAdmin):
     model = Round
+    choose_parent_view_class = RoundFundChooserView
+    choose_parent_template_name = 'funds/admin/parent_chooser.html'
     menu_icon = 'doc-empty'
     list_display = ('title', 'fund', 'start_date', 'end_date')
     button_helper_class = ButtonsWithPreview

--- a/opentech/apply/funds/admin.py
+++ b/opentech/apply/funds/admin.py
@@ -29,7 +29,6 @@ class RoundFundChooserView(ChooseParentView):
         return FundChooserForm(parents, request.POST or None)
 
 
-
 class ButtonsWithPreview(PageButtonHelper):
     def preview_button(self, obj, classnames_add, classnames_exclude):
         classnames = self.copy_button_classnames + classnames_add

--- a/opentech/apply/funds/templates/funds/admin/parent_chooser.html
+++ b/opentech/apply/funds/templates/funds/admin/parent_chooser.html
@@ -1,0 +1,28 @@
+{% extends "modeladmin/choose_parent.html" %}
+{% load i18n admin_static %}
+
+{% block content %}
+<div>
+    {% block header %}
+        {% include "modeladmin/includes/breadcrumb.html" %}
+        {% include "wagtailadmin/shared/header.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
+    {% endblock %}
+
+    <div class="nice-padding">
+        <h2>{% blocktrans %}Choose a Fund{% endblocktrans %}</h2>
+        <p>{% blocktrans with view.verbose_name_plural|capfirst as plural %}{{ plural }} must be associated with a Fund. For which Fund are you creating a new {{ view.verbose_name|capfirst }} for?{% endblocktrans %}</p>
+
+        <form action="" method="post" novalidate>
+            {% csrf_token %}
+
+            <ul class="fields">
+                {% include "wagtailadmin/shared/field_as_li.html" with field=form.parent_page %}
+                <li>
+                    <input type="submit" class="button" value="{% trans 'Continue' %}">
+                </li>
+            </ul>
+        </form>
+
+    </div>
+</div>
+{% endblock %}

--- a/opentech/apply/funds/templates/funds/admin/parent_chooser.html
+++ b/opentech/apply/funds/templates/funds/admin/parent_chooser.html
@@ -10,7 +10,7 @@
 
     <div class="nice-padding">
         <h2>{% blocktrans %}Choose a Fund{% endblocktrans %}</h2>
-        <p>{% blocktrans with view.verbose_name_plural|capfirst as plural %}{{ plural }} must be associated with a Fund. For which Fund are you creating a new {{ view.verbose_name|capfirst }} for?{% endblocktrans %}</p>
+        <p>{% blocktrans %}Rounds must be associated with a Fund. For which Fund are you creating a new Round for?{% endblocktrans %}</p>
 
         <form action="" method="post" novalidate>
             {% csrf_token %}


### PR DESCRIPTION
As requested in the review of feature 34, makes the parent chooser page more in keeping with funds/rounds.