### PR TITLE
Prevent errors when there is no round defined for a fund

### DIFF
--- a/opentech/apply/funds/models.py
+++ b/opentech/apply/funds/models.py
@@ -207,7 +207,11 @@ class FundType(EmailForm, WorkflowStreamForm):  # type: ignore
         ).first()
 
     def next_deadline(self):
-        return self.open_round.end_date
+        try:
+            return self.open_round.end_date
+        except AttributeError:
+            # There isn't an open round
+            return None
 
     def serve(self, request):
         if hasattr(request, 'is_preview') or not self.open_round:

--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -70,7 +70,7 @@ class TestFundModel(TestCase):
         self.assertEqual(self.fund.open_round, None)
 
     def test_no_round_exists(self):
-        self.assertIsNone(self.fund.next_deadline()
+        self.assertIsNone(self.fund.next_deadline())
 
 
 class TestRoundModelDates(TestCase):

--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -69,6 +69,9 @@ class TestFundModel(TestCase):
         new_round.save()
         self.assertEqual(self.fund.open_round, None)
 
+    def test_no_round_exists(self):
+        self.assertIsNone(self.fund.next_deadline()
+
 
 class TestRoundModelDates(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes a 500 that was happening on staging. When a fund exists but no rounds have ever been created this would cause an error. 

I've returned None as that is a valid response for the end date. This is mainly used when rendering the deadline onto listing items. You need to combine `next_deadline` with `is_open` to confirm that there is a round someone can apply for. 