### PR TITLE
adding reviewers block template and corresponding styles

### DIFF
--- a/opentech/public/funds/templates/public_funds/blocks/related_reviewers.html
+++ b/opentech/public/funds/templates/public_funds/blocks/related_reviewers.html
@@ -3,7 +3,7 @@
         <div class="wrapper--media-boxes">
             <div class="grid grid--two grid--medium-gap">
                 {% for person in page.reviewers.all %}
-                    {% include "people/includes/person_listing.html" with person=person.reviewer.specific %}
+                    {% include "public_funds/includes/reviewer_listing.html" with person=person.reviewer.specific %}
                 {% endfor %}
             </div>
         </div>

--- a/opentech/public/funds/templates/public_funds/includes/reviewer_listing.html
+++ b/opentech/public/funds/templates/public_funds/includes/reviewer_listing.html
@@ -4,13 +4,14 @@
     {% include "utils/includes/media_box_icon.html" with page_icon=person_photo listing=True %}
 
     <div class="media-box__content">
-        {% for type in person.person_types.all %}
-            <h6 class="media-box__category">{{ type }}</h6>
-        {% endfor %}
+        {% if person.person_types.exists %}
+            {% for type in person.person_types.all %}
+                <h6 class="media-box__category">{{ type }}</h6>
+            {% endfor %}
+        {% endif %}
         <h3 class="heading heading--no-margin">{{ person.first_name }} {{ person.last_name }}</h3>
         {% if person.job_title %}
             <p class="media-box__job-title">{{ person.job_title }}</p>
         {% endif %}
     </div>
 </a>
-

--- a/opentech/public/funds/templates/public_funds/includes/reviewer_listing.html
+++ b/opentech/public/funds/templates/public_funds/includes/reviewer_listing.html
@@ -1,0 +1,16 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+<a class="media-box" href="{% pageurl person %}">
+    {% image person.photo max-210x235 as person_photo %}
+    {% include "utils/includes/media_box_icon.html" with page_icon=person_photo listing=True %}
+
+    <div class="media-box__content">
+        {% for type in person.person_types.all %}
+            <h6 class="media-box__category">{{ type }}</h6>
+        {% endfor %}
+        <h3 class="heading heading--no-margin">{{ person.first_name }} {{ person.last_name }}</h3>
+        {% if person.job_title %}
+            <p class="media-box__job-title">{{ person.job_title }}</p>
+        {% endif %}
+    </div>
+</a>
+

--- a/opentech/static_src/src/sass/public/components/_media-box.scss
+++ b/opentech/static_src/src/sass/public/components/_media-box.scss
@@ -181,4 +181,24 @@
             }
         }
     }
+
+    &__category {
+        margin-bottom: 5px;
+        color: $color--default;
+    }
+
+    &__job-title {
+        margin: 5px 0 0;
+        color: $color--default;
+    }
+
+    &__category,
+    &__job-title {
+        transition: color $transition;
+
+        #{$root}:hover & {
+            color: $color--white;
+        }
+    }
+
 }


### PR DESCRIPTION
Front end work for the reviewers block used on the fund page.
Changed from using the `person_listing.html` partial as this is used on the person index page.