### PR TITLE
Bugfix/allow progression of application

### DIFF
--- a/opentech/apply/funds/tests/test_views.py
+++ b/opentech/apply/funds/tests/test_views.py
@@ -23,7 +23,15 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         response = self.get_page(submission)
         self.assertContains(response, submission.title)
 
-    def test_can_progress_stage(self):
+    def test_can_progress_phase(self):
+        submission = ApplicationSubmissionFactory()
+        next_status = list(submission.get_actions_for_user(self.user))[0][0]
+        self.post_page(submission, {'form-submitted-progress_form': '', 'action': next_status})
+
+        submission = self.refresh(submission)
+        self.assertEqual(submission.status, next_status)
+
+    def test_redirected_to_determination(self):
         submission = ApplicationSubmissionFactory(status='concept_review_discussion', workflow_stages=2, lead=self.user)
         response = self.post_page(submission, {'form-submitted-progress_form': '', 'action': 'invited_to_proposal'})
 

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -80,6 +80,8 @@ class ProgressSubmissionView(DelegatedViewMixin, UpdateView):
                 'apply:submissions:determinations:form',
                 args=(form.instance.id,)) + "?action=" + action)
 
+        self.object.perform_transition(action, self.request.user)
+
         return super().form_valid(form)
 
 


### PR DESCRIPTION
It looks like the old test that covered this was fixed in a way that meant this was no longer checked progression of the phase. TBH it was a bad test as it covered multiple behaviours.

Add a new test which tests the progression explicitly.