### PR TITLE
Fix the issue with bytes in urls

### DIFF
--- a/opentech/apply/users/templates/users/activation/email.txt
+++ b/opentech/apply/users/templates/users/activation/email.txt
@@ -4,7 +4,7 @@ Dear {{ name|default:username }},
 
 An account on Open Technology Fund has been created. Activate your account by clicking this link or copying and pasting it to your browser:
 
-{% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{% url 'users:activate' uidb64=uid token=token %}
+{% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{{ activation_path }}
 
 This link can be used once to log in and will lead you to a page where you can set your password.
 

--- a/opentech/apply/users/templates/users/activation/email_subject.txt
+++ b/opentech/apply/users/templates/users/activation/email_subject.txt
@@ -1,1 +1,0 @@
-Account details for {{ username }} at Open Technology Fund

--- a/opentech/apply/users/tests/test_utils.py
+++ b/opentech/apply/users/tests/test_utils.py
@@ -1,0 +1,12 @@
+from django.core import mail
+from django.test import TestCase
+
+from opentech.apply.users.tests.factories import UserFactory
+
+from ..utils import send_activation_email
+
+
+class TestActivationEmail(TestCase):
+    def test_activation_email_includes_link(self):
+        send_activation_email(UserFactory())
+        self.assertEqual(len(mail.outbox), 1)

--- a/opentech/apply/users/utils.py
+++ b/opentech/apply/users/utils.py
@@ -3,6 +3,7 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.template.loader import render_to_string
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+from django.urls import reverse
 
 
 def can_use_oauth_check(user):
@@ -20,23 +21,29 @@ def can_use_oauth_check(user):
     return False
 
 
-def send_activation_email(user, site):
+def send_activation_email(user, site=None):
     """
     Send the activation email. The activation key is the username,
     signed using TimestampSigner.
     """
     token_generator = PasswordResetTokenGenerator()
+    token = token_generator.make_token(user)
+
+    uid = urlsafe_base64_encode(force_bytes(user.pk)).decode()
+
+    activation_path = reverse('users:activate', kwargs={'uidb64': uid, 'token': token})
+
     context = {
         'user': user,
         'name': user.get_full_name(),
         'username': user.get_username(),
-        'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-        'token': token_generator.make_token(user),
+        'activation_path': activation_path,
     }
+
     if site:
         context.update(site=site)
 
-    subject = render_to_string('users/activation/email_subject.txt', context)
+    subject = 'Account details for {username} at Open Technology Fund'.format(**context)
     # Force subject to a single line to avoid header-injection issues.
     subject = ''.join(subject.splitlines())
     message = render_to_string('users/activation/email.txt', context)


### PR DESCRIPTION
Django was using the `b''` identifier in the url, hence the `&#39` we were seeing the urls for activation. `decode()` the bytes back to a string resolves the issue.