### PR TITLE
Mark the help text as safe

### DIFF
--- a/opentech/apply/funds/templates/funds/includes/field.html
+++ b/opentech/apply/funds/templates/funds/includes/field.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     {% if field.help_text %}
-        <p class="form__help">{{ field.help_text }}</p>
+        <p class="form__help">{{ field.help_text|safe }}</p>
     {% endif %}
 
     <div class="form__item">


### PR DESCRIPTION
will impact rendering of django password validators and admin input only so
considered reasonably safe.