### PR TITLE
Feature/261 fix applicants being logged out on application

### DIFF
--- a/opentech/apply/determinations/tests/test_views.py
+++ b/opentech/apply/determinations/tests/test_views.py
@@ -1,42 +1,18 @@
-from django.test import TestCase, RequestFactory
 from django.urls import reverse
 
 from opentech.apply.activity.models import Activity
 from opentech.apply.determinations.models import ACCEPTED
 from opentech.apply.users.tests.factories import StaffFactory, UserFactory
 from opentech.apply.funds.tests.factories import ApplicationSubmissionFactory
+from opentech.apply.utils.testing import BaseViewTestCase
 
 from .factories import DeterminationFactory
 
 
-class BaseTestCase(TestCase):
-    url_name = ''
-    user_factory = None
-
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.user = self.user_factory()
-        self.client.force_login(self.user)
-
-    def url(self, instance, view_name='detail'):
-        full_url_name = self.url_name.format(view_name)
-        url = reverse(full_url_name, kwargs=self.get_kwargs(instance))
-        request = self.factory.get(url, secure=True)
-        return request.build_absolute_uri()
-
-    def get_page(self, instance, view_name='detail'):
-        return self.client.get(self.url(instance, view_name), secure=True, follow=True)
-
-    def post_page(self, instance, data, view_name='detail'):
-        return self.client.post(self.url(instance, view_name), data, secure=True, follow=True)
-
-    def refresh(self, instance):
-        return instance.__class__.objects.get(id=instance.id)
-
-
-class StaffDeterminationsTestCase(BaseTestCase):
+class StaffDeterminationsTestCase(BaseViewTestCase):
     user_factory = StaffFactory
     url_name = 'funds:submissions:determinations:{}'
+    base_view_name = 'detail'
 
     def get_kwargs(self, instance):
         return {'submission_pk': instance.submission.id}
@@ -60,9 +36,10 @@ class StaffDeterminationsTestCase(BaseTestCase):
         self.assertTrue(response.context['can_view_extended_data'])
 
 
-class DeterminationFormTestCase(BaseTestCase):
+class DeterminationFormTestCase(BaseViewTestCase):
     user_factory = StaffFactory
     url_name = 'funds:submissions:determinations:{}'
+    base_view_name = 'detail'
 
     def get_kwargs(self, instance):
         return {'submission_pk': instance.id}
@@ -141,9 +118,10 @@ class DeterminationFormTestCase(BaseTestCase):
         self.assertEqual(submission_next.status, 'draft_proposal')
 
 
-class UserDeterminationFormTestCase(BaseTestCase):
+class UserDeterminationFormTestCase(BaseViewTestCase):
     user_factory = UserFactory
     url_name = 'funds:submissions:determinations:{}'
+    base_view_name = 'detail'
 
     def get_kwargs(self, instance):
         return {'submission_pk': instance.id}

--- a/opentech/apply/funds/tests/factories/models.py
+++ b/opentech/apply/funds/tests/factories/models.py
@@ -100,7 +100,6 @@ class FundTypeFactory(wagtail_factories.PageFactory):
                 ReviewFormFactory(**review_fields)
 
 
-
 class RequestForPartnersFactory(FundTypeFactory):
     class Meta:
         model = RequestForPartners

--- a/opentech/apply/funds/tests/factories/models.py
+++ b/opentech/apply/funds/tests/factories/models.py
@@ -21,6 +21,7 @@ from opentech.apply.funds.models.forms import (
 )
 from opentech.apply.users.tests.factories import StaffFactory, UserFactory
 from opentech.apply.stream_forms.testing.factories import FormDataFactory
+from opentech.apply.home.factories import ApplyHomePageFactory
 
 from . import blocks
 
@@ -70,6 +71,21 @@ class FundTypeFactory(wagtail_factories.PageFactory):
     workflow_name = factory.LazyAttribute(lambda o: list(FundType.WORKFLOW_CHOICES.keys())[o.workflow_stages - 1])
 
     @factory.post_generation
+    def parent(self, create, extracted_parent, **parent_kwargs):
+        # THIS MUST BE THE FIRST POST GENERATION METHOD OR THE OBJECT WILL BE UNSAVED
+        if create:
+            if extracted_parent and parent_kwargs:
+                raise ValueError('Cant pass a parent instance and attributes')
+
+            if not extracted_parent:
+                parent = ApplyHomePageFactory(**parent_kwargs)
+            else:
+                # Assume root node if no parent passed
+                parent = extracted_parent
+
+            parent.add_child(instance=self)
+
+    @factory.post_generation
     def forms(self, create, extracted, **kwargs):
         if create:
             from opentech.apply.review.tests.factories.models import build_form as review_build_form, ReviewFormFactory
@@ -82,6 +98,7 @@ class FundTypeFactory(wagtail_factories.PageFactory):
                     **fields,
                 )
                 ReviewFormFactory(**review_fields)
+
 
 
 class RequestForPartnersFactory(FundTypeFactory):
@@ -98,7 +115,7 @@ class AbstractRelatedFormFactory(factory.DjangoModelFactory):
 class ApplicationBaseFormFactory(AbstractRelatedFormFactory):
     class Meta:
         model = ApplicationBaseForm
-    application = factory.SubFactory(FundTypeFactory, parent=None)
+    application = factory.SubFactory(FundTypeFactory)
 
 
 class ApplicationFormFactory(factory.DjangoModelFactory):
@@ -120,7 +137,7 @@ class RoundFactory(wagtail_factories.PageFactory):
         )
 
     title = factory.Sequence('Round {}'.format)
-    start_date = factory.Sequence(lambda n: datetime.date.today() + datetime.timedelta(days=7 * n))
+    start_date = factory.Sequence(lambda n: datetime.date.today() + datetime.timedelta(days=7 * n + 1))
     end_date = factory.Sequence(lambda n: datetime.date.today() + datetime.timedelta(days=7 * (n + 1)))
     lead = factory.SubFactory(StaffFactory)
 
@@ -149,7 +166,7 @@ class TodayRoundFactory(RoundFactory):
 class RoundBaseFormFactory(AbstractRelatedFormFactory):
     class Meta:
         model = RoundBaseForm
-    round = factory.SubFactory(RoundFactory, parent=None)
+    round = factory.SubFactory(RoundFactory)
 
 
 class LabFactory(wagtail_factories.PageFactory):
@@ -179,7 +196,7 @@ class LabFactory(wagtail_factories.PageFactory):
 class LabBaseFormFactory(AbstractRelatedFormFactory):
     class Meta:
         model = LabBaseForm
-    lab = factory.SubFactory(LabFactory, parent=None)
+    lab = factory.SubFactory(LabFactory)
 
 
 class ApplicationFormDataFactory(FormDataFactory):

--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -179,6 +179,7 @@ class TestRoundModelWorkflowAndForms(TestCase):
             self.assertNotEqual(round_form, fund_form)
 
 
+@override_settings(ROOT_URLCONF='opentech.apply.urls')
 class TestFormSubmission(TestCase):
     def setUp(self):
         self.site = Site.objects.first()

--- a/opentech/apply/home/factories.py
+++ b/opentech/apply/home/factories.py
@@ -1,0 +1,14 @@
+import factory
+import wagtail_factories
+
+from .models import ApplyHomePage
+
+
+class ApplyHomePageFactory(wagtail_factories.PageFactory):
+    class Meta:
+        model = ApplyHomePage
+
+    @factory.post_generation
+    def site(self, create, extracted_site, **site_kwargs):
+        if create:
+            wagtail_factories.SiteFactory(root_page=self, is_default_site=True)

--- a/opentech/apply/middleware.py
+++ b/opentech/apply/middleware.py
@@ -1,0 +1,17 @@
+from .home.models import ApplyHomePage
+
+
+def apply_url_conf_middleware(get_response):
+    # If we are on a page which belongs to the same site as an ApplyHomePage
+    # we change the url conf to one that includes links to all the logged
+    # in functionality. Login and Logout are included with the global package
+    # of urls
+    def middleware(request):
+        homepage = request.site.root_page.specific
+        if isinstance(homepage, ApplyHomePage):
+            request.urlconf = 'opentech.apply.urls'
+
+        response = get_response(request)
+        return response
+
+    return middleware

--- a/opentech/apply/urls.py
+++ b/opentech/apply/urls.py
@@ -3,11 +3,15 @@ from django.urls import include, path
 from .users import urls as users_urls
 from .dashboard import urls as dashboard_urls
 
+from opentech.urls import urlpatterns as base_urlpatterns
+
 
 urlpatterns = [
     path('apply/', include('opentech.apply.funds.urls', 'apply')),
     path('activity/', include('opentech.apply.activity.urls', 'activity')),
-    path('account/', include(users_urls)),
+    path('', include(users_urls)),
     path('dashboard/', include(dashboard_urls)),
     path('hijack/', include('hijack.urls', 'hijack')),
 ]
+
+urlpatterns += base_urlpatterns

--- a/opentech/apply/users/templates/users/password_reset/complete.html
+++ b/opentech/apply/users/templates/users/password_reset/complete.html
@@ -4,6 +4,6 @@
 {% block title %}{% trans "Reset password" %}{% endblock %} {% block content %}
     <h1>{% trans "Password change successful" %}</h1>
     <p>
-        <a href="{% url 'users:login' %}">{% trans "Log in" %}</a>
+        <a href="{% url 'users_public:login' %}">{% trans "Log in" %}</a>
     </p>
 {% endblock %}

--- a/opentech/apply/users/tests/test_oauth_access.py
+++ b/opentech/apply/users/tests/test_oauth_access.py
@@ -4,6 +4,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 
+@override_settings(ROOT_URLCONF='opentech.apply.urls')
 class TestOAuthAccess(TestCase):
     def login(self):
         email = 'test@email.com'
@@ -19,8 +20,12 @@ class TestOAuthAccess(TestCase):
         """
         oauth_page = reverse('users:oauth')
         response = self.client.get(oauth_page, follow=True)
-        self.assertRedirects(response, reverse(
-            'users:login') + '?next=' + reverse('users:oauth'), status_code=301, target_status_code=200)
+        self.assertRedirects(
+            response,
+            reverse('users_public:login') + '?next=' + reverse('users:oauth'),
+            status_code=301,
+            target_status_code=200,
+        )
 
     @override_settings()
     def test_oauth_not_set_up(self):

--- a/opentech/apply/users/tests/test_views.py
+++ b/opentech/apply/users/tests/test_views.py
@@ -1,9 +1,10 @@
-from django.test import TestCase
+from django.test import override_settings, TestCase
 from django.urls import reverse
 
 from .factories import OAuthUserFactory, StaffFactory, UserFactory
 
 
+@override_settings(ROOT_URLCONF='opentech.apply.urls')
 class BaseTestProfielView(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -19,7 +20,7 @@ class TestProfileView(BaseTestProfielView):
         self.client.logout()
         response = self.client.get(self.url, follow=True)
         # Initial redirect will be via to https through a 301
-        self.assertRedirects(response, reverse('users:login') + '?next=' + self.url, status_code=301)
+        self.assertRedirects(response, reverse('users_public:login') + '?next=' + self.url, status_code=301)
 
     def test_includes_change_password(self):
         response = self.client.get(self.url, follow=True)

--- a/opentech/apply/users/urls.py
+++ b/opentech/apply/users/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, include
 from django.contrib.auth import views as auth_views
 from django.urls import reverse_lazy
 
@@ -7,9 +7,8 @@ from opentech.apply.users.views import AccountView, become, oauth, ActivationVie
 
 app_name = 'users'
 
-urlpatterns = [
-    path('', AccountView.as_view(), name='account'),
-    path('become/', become, name='become'),
+
+public_urlpatterns = [
     path(
         'login/',
         auth_views.LoginView.as_view(
@@ -21,52 +20,62 @@ urlpatterns = [
 
     # Log out
     path('logout/', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
+]
 
-    # Password change
-    path(
-        'password/',
-        auth_views.PasswordChangeView.as_view(
-            template_name="users/change_password.html",
-            success_url=reverse_lazy('users:account')
-        ),
-        name='password_change',
-    ),
 
-    # Password reset
-    path(
-        'reset/',
-        auth_views.PasswordResetView.as_view(
-            template_name='users/password_reset/form.html',
-            email_template_name='users/password_reset/email.txt',
-            success_url=reverse_lazy('users:password_reset_done')
-        ),
-        name='password_reset',
-    ),
-    path(
-        'reset/done/',
-        auth_views.PasswordResetDoneView.as_view(template_name='users/password_reset/done.html'),
-        name='password_reset_done'
-    ),
-    path(
-        'reset/confirm/<uidb64>/<token>/',
-        auth_views.PasswordResetConfirmView.as_view(
-            template_name='users/password_reset/confirm.html',
-            post_reset_login=True,
-            post_reset_login_backend='django.contrib.auth.backends.ModelBackend',
-            success_url=reverse_lazy('users:account')
-        ),
-        name='password_reset_confirm'
-    ),
-    path(
-        'reset/complete/',
-        auth_views.PasswordResetCompleteView.as_view(template_name='users/password_reset/complete.html'),
-        name='password_reset_complete'
-    ),
-    path(
-        'activate/<uidb64>/<token>/',
-        ActivationView.as_view(),
-        name='activate'
-    ),
-    path('activate/password/', create_password, name="activate_password"),
-    path('oauth', oauth, name='oauth'),
+urlpatterns = [
+    path('account/', include([
+        path('', AccountView.as_view(), name='account'),
+        path('become/', become, name='become'),
+        # Password change
+        path('password/', include([
+            path(
+                'change/',
+                auth_views.PasswordChangeView.as_view(
+                    template_name="users/change_password.html",
+                    success_url=reverse_lazy('users:account')
+                ),
+                name='password_change',
+            ),
+
+            # Password reset
+            path(
+                'reset/',
+                auth_views.PasswordResetView.as_view(
+                    template_name='users/password_reset/form.html',
+                    email_template_name='users/password_reset/email.txt',
+                    success_url=reverse_lazy('users:password_reset_done')
+                ),
+                name='password_reset',
+            ),
+            path(
+                'reset/done/',
+                auth_views.PasswordResetDoneView.as_view(template_name='users/password_reset/done.html'),
+                name='password_reset_done'
+            ),
+            path(
+                'reset/confirm/<uidb64>/<token>/',
+                auth_views.PasswordResetConfirmView.as_view(
+                    template_name='users/password_reset/confirm.html',
+                    post_reset_login=True,
+                    post_reset_login_backend='django.contrib.auth.backends.ModelBackend',
+                    success_url=reverse_lazy('users:account')
+                ),
+                name='password_reset_confirm'
+            ),
+            path(
+                'reset/complete/',
+                auth_views.PasswordResetCompleteView.as_view(template_name='users/password_reset/complete.html'),
+                name='password_reset_complete'
+            ),
+            path(
+                'activate/<uidb64>/<token>/',
+                ActivationView.as_view(),
+                name='activate'
+            ),
+            path('activate/', create_password, name="activate_password"),
+
+        ])),
+        path('oauth', oauth, name='oauth'),
+    ]))
 ]

--- a/opentech/apply/users/urls.py
+++ b/opentech/apply/users/urls.py
@@ -27,7 +27,6 @@ urlpatterns = [
     path('account/', include([
         path('', AccountView.as_view(), name='account'),
         path('become/', become, name='become'),
-        # Password change
         path('password/', include([
             path(
                 'change/',
@@ -37,8 +36,6 @@ urlpatterns = [
                 ),
                 name='password_change',
             ),
-
-            # Password reset
             path(
                 'reset/',
                 auth_views.PasswordResetView.as_view(
@@ -68,14 +65,13 @@ urlpatterns = [
                 auth_views.PasswordResetCompleteView.as_view(template_name='users/password_reset/complete.html'),
                 name='password_reset_complete'
             ),
-            path(
-                'activate/<uidb64>/<token>/',
-                ActivationView.as_view(),
-                name='activate'
-            ),
-            path('activate/', create_password, name="activate_password"),
-
         ])),
+        path(
+            'activate/<uidb64>/<token>/',
+            ActivationView.as_view(),
+            name='activate'
+        ),
+        path('activate/', create_password, name="activate_password"),
         path('oauth', oauth, name='oauth'),
     ]))
 ]

--- a/opentech/apply/users/views.py
+++ b/opentech/apply/users/views.py
@@ -49,7 +49,7 @@ class AccountView(UpdateView):
         )
 
 
-@login_required(login_url=reverse_lazy('users:login'))
+@login_required()
 def become(request):
     if request.POST:
         id = request.POST['user']
@@ -57,7 +57,7 @@ def become(request):
     return redirect('users:account')
 
 
-@login_required(login_url=reverse_lazy('users:login'))
+@login_required()
 @require_oauth_whitelist
 def oauth(request):
     """Generic, empty view for the OAuth associations."""

--- a/opentech/apply/utils/testing/tests.py
+++ b/opentech/apply/utils/testing/tests.py
@@ -1,6 +1,6 @@
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.auth.models import AnonymousUser
-from django.test import TestCase, RequestFactory
+from django.test import override_settings, TestCase, RequestFactory
 from django.urls import reverse
 
 
@@ -17,6 +17,7 @@ def make_request(user=AnonymousUser(), data={}, method='get', site=None):
     return request
 
 
+@override_settings(ROOT_URLCONF='opentech.apply.urls')
 class BaseViewTestCase(TestCase):
     url_name = ''  # resolvable url, you should use "path:to:view:{}" and {} with be replaced with base_view_name
     base_view_name = ''

--- a/opentech/public/home/templates/home/home_page.html
+++ b/opentech/public/home/templates/home/home_page.html
@@ -52,10 +52,7 @@
             </section>
 
             <div class="header__button-container">
-                <a href="{% url 'users:login' %}" class="button button--transparent button--contains-icons">
-                    <svg class="icon icon--person"><use xlink:href="#person-icon"></use></svg>
-                    My OTF
-                </a>
+                {% include "utils/includes/login_button.html" %}
                 <div class="button button--google-translate" id="google_translate_element"></div>
             </div>
         </div>

--- a/opentech/public/navigation/templates/navigation/primarynav.html
+++ b/opentech/public/navigation/templates/navigation/primarynav.html
@@ -6,8 +6,5 @@
         {% endfor %}
     </ul>
 </nav>
-<a href="{% url 'users:login' %}" class="link link--button-transparent link--mobile-standout">
-    <svg class="icon"><use xlink:href="#person-icon"></use></svg>
-    My OTF
-</a>
-<a href="#" class="link link--button-secondary link--mobile-standout">Apply</a>
+{% include "utils/includes/login_button.html" with class="link--mobile-standout" %}
+<a href="{% pageurl APPLY_SITE.root_page %}" class="link link--button-secondary link--mobile-standout">Apply</a>

--- a/opentech/public/navigation/templatetags/navigation_tags.py
+++ b/opentech/public/navigation/templatetags/navigation_tags.py
@@ -14,9 +14,11 @@ esi_inclusion_tag = register_inclusion_tag(register)
 def primarynav(context):
     request = context['request']
     site = context.get('PUBLIC_SITE', request.site)
+    apply_site = context.get('APPLY_SITE', request.site)
     return {
         'primarynav': NavigationSettings.for_site(site).primary_navigation,
         'request': request,
+        'APPLY_SITE': apply_site,
     }
 
 

--- a/opentech/public/utils/templates/utils/includes/login_button.html
+++ b/opentech/public/utils/templates/utils/includes/login_button.html
@@ -1,0 +1,4 @@
+<a href="{{ request.scheme }}://{{ APPLY_SITE }}{% url 'users_public:login' %}" class="button button--transparent button--contains-icons {{ class }}">
+    <svg class="icon icon--person"><use xlink:href="#person-icon"></use></svg>
+    My OTF
+</a>

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -95,6 +95,8 @@ MIDDLEWARE = [
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'opentech.public.esi.middleware.ESIMiddleware',
+
+    'opentech.apply.middleware.apply_url_conf_middleware',
 ]
 
 ROOT_URLCONF = 'opentech.urls'
@@ -218,13 +220,14 @@ WAGTAIL_USER_EDIT_FORM = 'opentech.apply.users.forms.CustomUserEditForm'
 WAGTAIL_USER_CREATION_FORM = 'opentech.apply.users.forms.CustomUserCreationForm'
 WAGTAIL_USER_CUSTOM_FIELDS = ['full_name']
 
-LOGIN_URL = 'users:login'
+LOGIN_URL = 'users_public:login'
 LOGIN_REDIRECT_URL = 'dashboard:dashboard'
 
 AUTHENTICATION_BACKENDS = (
     'social_core.backends.google.GoogleOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 )
+
 
 # Logging
 

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -320,7 +320,7 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS = STAFF_EMAIL_DOMAINS
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = ''
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = ''
 
-SOCIAL_AUTH_LOGIN_ERROR_URL = 'users:login'
+SOCIAL_AUTH_LOGIN_ERROR_URL = 'users_public:login'
 SOCIAL_AUTH_NEW_ASSOCIATION_REDIRECT_URL = 'users:account'
 
 # For pipelines, see http://python-social-auth.readthedocs.io/en/latest/pipeline.html?highlight=pipelines#authentication-pipeline

--- a/opentech/templates/base-apply.html
+++ b/opentech/templates/base-apply.html
@@ -73,7 +73,7 @@
                         <svg class="icon"><use xlink:href="#person-icon"></use></svg>
                         {{ request.user }}
                     </a>
-                    <a href="{% url 'users:logout' %}" class="link link--button-transparent link--mobile-standout">Logout</a>
+                    <a href="{% url 'users_public:logout' %}" class="link link--button-transparent link--mobile-standout">Logout</a>
                 </section>
 
                 <div class="header__button-container">
@@ -81,7 +81,7 @@
                         <svg class="icon icon--person"><use xlink:href="#person-icon"></use></svg>
                         {{ request.user }}
                     </a>
-                    <a href="{% url 'users:logout' %}" class="button button--transparent button--narrow">
+                    <a href="{% url 'users_public:logout' %}" class="button button--transparent button--narrow">
                         Log Out
                     </a>
                 </div>

--- a/opentech/templates/base.html
+++ b/opentech/templates/base.html
@@ -118,10 +118,7 @@
                     </section>
 
                     <div class="header__button-container">
-                        <a href="{% url 'users:login' %}" class="button button--transparent button--contains-icons">
-                            <svg class="icon icon--person"><use xlink:href="#person-icon"></use></svg>
-                            My OTF
-                        </a>
+                        {% include "utils/includes/login_button.html" %}
                         <div class="button button--google-translate" id="google_translate_element"></div>
                     </div>
                 </div>

--- a/opentech/urls.py
+++ b/opentech/urls.py
@@ -11,7 +11,7 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 from opentech.public import urls as public_urls
-from opentech.apply import urls as apply_urls
+from opentech.apply.users.urls import public_urlpatterns as user_urls
 
 
 urlpatterns = [
@@ -21,7 +21,7 @@ urlpatterns = [
     path('documents/', include(wagtaildocs_urls)),
     path('sitemap.xml', sitemap),
     path('', include(public_urls)),
-    path('', include(apply_urls)),
+    path('', include((user_urls, 'users_public'))),
     path('', include('social_django.urls', namespace='social')),
     path('tinymce/', include('tinymce.urls')),
     path('select2/', include('django_select2.urls')),


### PR DESCRIPTION
Tidy up the urls for users so we can expose the public login urls without including all the urls for the apply site. Also tidy up how the templates works to reduce duplication.

Added a middleware which changes the url conf to grant access to the apply site if identified as the domain the request originates from.