### PR TITLE
Feature/298 small fixes

### DIFF
--- a/opentech/apply/dashboard/templates/dashboard/dashboard.html
+++ b/opentech/apply/dashboard/templates/dashboard/dashboard.html
@@ -9,8 +9,9 @@
         {% block page_header %}
             <h1 class="gamma heading heading--no-margin heading--bold">Dashboard</h1>
         {% endblock %}
-        <a href="{% url 'wagtailadmin_home' %}" class="button button--primary {{ class }}}">
+        <a href="{% url 'wagtailadmin_home' %}" class="button button--primary button--arrow-pixels-white">
             Apply admin
+            <svg><use xlink:href="#arrow-head-pixels--solid"></use></svg>
         </a>
     </div>
 </div>

--- a/opentech/apply/determinations/views.py
+++ b/opentech/apply/determinations/views.py
@@ -134,6 +134,23 @@ class AdminDeterminationDetailView(DetailView):
 
 
 @method_decorator(login_required, name='dispatch')
+class ReviewerDeterminationDetailView(DetailView):
+    model = Determination
+
+    def get_object(self, queryset=None):
+        return self.model.objects.get(submission=self.submission)
+
+    def dispatch(self, request, *args, **kwargs):
+        self.submission = get_object_or_404(ApplicationSubmission, id=self.kwargs['submission_pk'])
+        determination = self.get_object()
+
+        if not determination.submitted:
+            return HttpResponseRedirect(reverse_lazy('apply:submissions:detail', args=(self.submission.id,)))
+
+        return super().dispatch(request, *args, **kwargs)
+
+
+@method_decorator(login_required, name='dispatch')
 class ApplicantDeterminationDetailView(DetailView):
     model = Determination
 
@@ -156,3 +173,4 @@ class ApplicantDeterminationDetailView(DetailView):
 class DeterminationDetailView(ViewDispatcher):
     admin_view = AdminDeterminationDetailView
     applicant_view = ApplicantDeterminationDetailView
+    reviewer_view = ReviewerDeterminationDetailView

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -459,7 +459,11 @@ class ApplicationSubmission(
 
         if creating:
             self.reviewers.set(self.get_from_parent('reviewers').all())
-            first_revision = ApplicationRevision.objects.create(submission=self, form_data=self.form_data)
+            first_revision = ApplicationRevision.objects.create(
+                submission=self,
+                form_data=self.form_data,
+                author=self.user,
+            )
             self.live_revision = first_revision
             self.draft_revision = first_revision
             self.save()

--- a/opentech/apply/funds/templates/funds/revisions_compare.html
+++ b/opentech/apply/funds/templates/funds/revisions_compare.html
@@ -10,6 +10,10 @@
 </div>
 
 <div class="wrapper wrapper--large wrapper--tabs">
+    <div>
+        <h2>{{ object.get_title_display }}</h2>
+    </div>
+
     {% include "funds/includes/rendered_answers.html" %}
 </div>
 {% endblock %}

--- a/opentech/apply/funds/templates/funds/tables/table.html
+++ b/opentech/apply/funds/templates/funds/tables/table.html
@@ -2,7 +2,14 @@
 {% load django_tables2 table_tags review_tags %}
 
 {% block table.tbody.row %}
-    {{ block.super }}
+    <tr {{ row.attrs.as_html }}>
+        {% for column, cell in row.items %}
+            <td {{ column.attrs.td.as_html }}>
+                <span class="mobile-label {{ column.attrs.td.class }}">{{ column.header }}: </span>
+                {% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}
+            </td>
+        {% endfor %}
+    </tr>
 
     {% with submission=row.record %}
         <tr class="all-submissions__child" data-parent-id="{{ row.record.id }}">

--- a/opentech/apply/funds/templates/funds/tables/table.html
+++ b/opentech/apply/funds/templates/funds/tables/table.html
@@ -11,7 +11,7 @@
                     <tr class="submission-meta__row">
                         <th><h6 class="heading heading--normal heading--no-margin">Applicant</h6></th>
                         <th><h6 class="heading heading--normal heading--no-margin">Last updated</h6></th>
-                        <th><h6 class="heading heading--normal heading--no-margin">Reviewers / Outcomes</h6></th>
+                        <th><h6 class="heading heading--normal heading--no-margin">Review outcomes</h6></th>
                     </tr>
                     <tr class="submission-meta__row submission-meta__row--black">
                         <td><strong>{{ submission.full_name }}</strong></td>

--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -381,6 +381,7 @@ class TestApplicationSubmission(TestCase):
         submission = ApplicationSubmissionFactory()
         self.assertEqual(submission.revisions.count(), 1)
         self.assertDictEqual(submission.live_revision.form_data, submission.form_data)
+        self.assertEqual(submission.live_revision.author, submission.user)
 
     def test_create_revision_on_data_change(self):
         submission = ApplicationSubmissionFactory()

--- a/opentech/apply/funds/tests/test_views.py
+++ b/opentech/apply/funds/tests/test_views.py
@@ -140,6 +140,12 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):
     user_factory = StaffFactory
 
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.staff = StaffFactory.create_batch(4)
+        cls.reviewers = ReviewerFactory.create_batch(4)
+
     def post_form(self, submission, staff=list(), reviewers=list()):
         return self.post_page(submission, {
             'form-submitted-reviewer_form': '',
@@ -149,82 +155,67 @@ class TestReviewersUpdateView(BaseSubmissionViewTestCase):
 
     def test_lead_can_add_staff_single(self):
         submission = ApplicationSubmissionFactory(lead=self.user)
-        staff = StaffFactory.create_batch(4)
 
-        self.post_form(submission, staff)
+        self.post_form(submission, self.staff)
 
-        self.assertCountEqual(submission.reviewers.all(), staff)
+        self.assertCountEqual(submission.reviewers.all(), self.staff)
 
     def test_lead_can_remove_staff_single(self):
-        staff = StaffFactory.create_batch(4)
-        submission = ApplicationSubmissionFactory(lead=self.user, reviewers=staff)
-        self.assertCountEqual(submission.reviewers.all(), staff)
+        submission = ApplicationSubmissionFactory(lead=self.user, reviewers=self.staff)
+        self.assertCountEqual(submission.reviewers.all(), self.staff)
 
         self.post_form(submission, [])
 
         self.assertCountEqual(submission.reviewers.all(), [])
 
     def test_lead_can_remove_some_staff(self):
-        staff = StaffFactory.create_batch(4)
-        submission = ApplicationSubmissionFactory(lead=self.user, reviewers=staff)
-        self.assertCountEqual(submission.reviewers.all(), staff)
+        submission = ApplicationSubmissionFactory(lead=self.user, reviewers=self.staff)
+        self.assertCountEqual(submission.reviewers.all(), self.staff)
 
-        self.post_form(submission, staff[0:2])
+        self.post_form(submission, self.staff[0:2])
 
-        self.assertCountEqual(submission.reviewers.all(), staff[0:2])
+        self.assertCountEqual(submission.reviewers.all(), self.staff[0:2])
 
     def test_lead_cant_add_reviewers_single(self):
         submission = ApplicationSubmissionFactory(lead=self.user)
-        reviewers = ReviewerFactory.create_batch(4)
 
-        self.post_form(submission, reviewers=reviewers)
+        self.post_form(submission, reviewers=self.reviewers)
 
         self.assertCountEqual(submission.reviewers.all(), [])
 
     def test_lead_can_add_staff_and_reviewers_for_proposal(self):
         submission = InvitedToProposalFactory(lead=self.user)
 
-        staff = StaffFactory.create_batch(4)
-        reviewers = ReviewerFactory.create_batch(4)
+        self.post_form(submission, self.staff, self.reviewers)
 
-        self.post_form(submission, staff, reviewers)
-
-        self.assertCountEqual(submission.reviewers.all(), staff + reviewers)
+        self.assertCountEqual(submission.reviewers.all(), self.staff + self.reviewers)
 
     def test_lead_can_remove_staff_and_reviewers_for_proposal(self):
-        staff = StaffFactory.create_batch(4)
-        reviewers = ReviewerFactory.create_batch(4)
-
-        submission = InvitedToProposalFactory(lead=self.user, reviewers=staff + reviewers)
-        self.assertCountEqual(submission.reviewers.all(), staff + reviewers)
+        submission = InvitedToProposalFactory(lead=self.user, reviewers=self.staff + self.reviewers)
+        self.assertCountEqual(submission.reviewers.all(), self.staff + self.reviewers)
 
         self.post_form(submission)
 
         self.assertCountEqual(submission.reviewers.all(), [])
 
     def test_lead_can_remove_some_staff_and_reviewers_for_proposal(self):
-        staff = StaffFactory.create_batch(4)
-        reviewers = ReviewerFactory.create_batch(4)
+        submission = InvitedToProposalFactory(lead=self.user, reviewers=self.staff + self.reviewers)
+        self.assertCountEqual(submission.reviewers.all(), self.staff + self.reviewers)
 
-        submission = InvitedToProposalFactory(lead=self.user, reviewers=staff + reviewers)
-        self.assertCountEqual(submission.reviewers.all(), staff + reviewers)
+        self.post_form(submission, self.staff[0:2], self.reviewers[0:2])
 
-        self.post_form(submission, staff[0:2], reviewers[0:2])
-
-        self.assertCountEqual(submission.reviewers.all(), staff[0:2] + reviewers[0:2])
+        self.assertCountEqual(submission.reviewers.all(), self.staff[0:2] + self.reviewers[0:2])
 
     def test_staff_can_add_staff_single(self):
         submission = ApplicationSubmissionFactory()
-        staff = StaffFactory.create_batch(4)
 
-        self.post_form(submission, staff)
+        self.post_form(submission, self.staff)
 
-        self.assertCountEqual(submission.reviewers.all(), staff)
+        self.assertCountEqual(submission.reviewers.all(), self.staff)
 
     def test_staff_can_remove_staff_single(self):
-        staff = StaffFactory.create_batch(4)
-        submission = ApplicationSubmissionFactory(reviewers=staff)
-        self.assertCountEqual(submission.reviewers.all(), staff)
+        submission = ApplicationSubmissionFactory(reviewers=self.staff)
+        self.assertCountEqual(submission.reviewers.all(), self.staff)
 
         self.post_form(submission, [])
 
@@ -232,21 +223,18 @@ class TestReviewersUpdateView(BaseSubmissionViewTestCase):
 
     def test_staff_cant_add_reviewers_proposal(self):
         submission = ApplicationSubmissionFactory()
-        reviewers = ReviewerFactory.create_batch(4)
 
-        self.post_form(submission, reviewers=reviewers)
+        self.post_form(submission, reviewers=self.reviewers)
 
         self.assertCountEqual(submission.reviewers.all(), [])
 
     def test_staff_cant_remove_reviewers_proposal(self):
-        reviewers = ReviewerFactory.create_batch(4)
-
-        submission = ApplicationSubmissionFactory(reviewers=reviewers)
-        self.assertCountEqual(submission.reviewers.all(), reviewers)
+        submission = ApplicationSubmissionFactory(reviewers=self.reviewers)
+        self.assertCountEqual(submission.reviewers.all(), self.reviewers)
 
         self.post_form(submission, reviewers=[])
 
-        self.assertCountEqual(submission.reviewers.all(), reviewers)
+        self.assertCountEqual(submission.reviewers.all(), self.reviewers)
 
 
 class TestApplicantSubmissionView(BaseSubmissionViewTestCase):

--- a/opentech/apply/funds/workflow.py
+++ b/opentech/apply/funds/workflow.py
@@ -158,7 +158,11 @@ SingleStageDefinition = {
     },
     'more_info': {
         'transitions': {
-            INITIAL_STATE: {'display': 'Submit', 'permissions': {UserPermissions.APPLICANT}, 'method': 'create_revision'},
+            INITIAL_STATE: {
+                'display': 'Submit',
+                'permissions': {UserPermissions.APPLICANT, UserPermissions.LEAD, UserPermissions.ADMIN},
+                'method': 'create_revision',
+            },
         },
         'display': 'More information required',
         'stage': Request,
@@ -187,7 +191,11 @@ SingleStageDefinition = {
     },
     'post_review_more_info': {
         'transitions': {
-            'post_review_discussion': {'display': 'Submit', 'permissions': {UserPermissions.APPLICANT}, 'method': 'create_revision'},
+            'post_review_discussion': {
+                'display': 'Submit',
+                'permissions': {UserPermissions.APPLICANT, UserPermissions.LEAD, UserPermissions.ADMIN},
+                'method': 'create_revision',
+            },
         },
         'display': 'More information required',
         'stage': Request,
@@ -224,7 +232,11 @@ DoubleStageDefinition = {
     },
     'concept_more_info': {
         'transitions': {
-            INITIAL_STATE: {'display': 'Submit', 'permissions': {UserPermissions.APPLICANT}, 'method': 'create_revision'},
+            INITIAL_STATE: {
+                'display': 'Submit',
+                'permissions': {UserPermissions.APPLICANT, UserPermissions.LEAD, UserPermissions.ADMIN},
+                'method': 'create_revision',
+            },
         },
         'display': 'More information required',
         'stage': Concept,
@@ -253,7 +265,11 @@ DoubleStageDefinition = {
     },
     'concept_review_more_info': {
         'transitions': {
-            'concept_review_discussion': {'display': 'Submit', 'permissions': {UserPermissions.APPLICANT}, 'method': 'create_revision'},
+            'concept_review_discussion': {
+                'display': 'Submit',
+                'permissions': {UserPermissions.APPLICANT, UserPermissions.LEAD, UserPermissions.ADMIN},
+                'method': 'create_revision',
+            },
         },
         'display': 'More information required',
         'stage': Concept,
@@ -302,7 +318,11 @@ DoubleStageDefinition = {
     },
     'proposal_more_info': {
         'transitions': {
-            'proposal_discussion': {'display': 'Submit', 'permissions': {UserPermissions.APPLICANT}, 'method': 'create_revision'},
+            'proposal_discussion': {
+                'display': 'Submit',
+                'permissions': {UserPermissions.APPLICANT, UserPermissions.LEAD, UserPermissions.ADMIN},
+                'method': 'create_revision',
+            },
         },
         'display': 'More information required',
         'stage': Proposal,
@@ -331,7 +351,11 @@ DoubleStageDefinition = {
     },
     'post_proposal_review_more_info': {
         'transitions': {
-            'post_proposal_review_discussion': {'display': 'Submit', 'permissions': {UserPermissions.APPLICANT}, 'method': 'create_revision'},
+            'post_proposal_review_discussion': {
+                'display': 'Submit',
+                'permissions': {UserPermissions.APPLICANT, UserPermissions.LEAD, UserPermissions.ADMIN},
+                'method': 'create_revision',
+            },
         },
         'display': 'More information required',
         'stage': Proposal,
@@ -360,7 +384,11 @@ DoubleStageDefinition = {
     },
     'post_external_review_more_info': {
         'transitions': {
-            'post_external_review_discussion': {'display': 'Submit', 'permissions': {UserPermissions.APPLICANT}, 'method': 'create_revision'},
+            'post_external_review_discussion': {
+                'display': 'Submit',
+                'permissions': {UserPermissions.APPLICANT, UserPermissions.LEAD, UserPermissions.ADMIN},
+                'method': 'create_revision',
+            },
         },
         'display': 'More information required',
         'stage': Proposal,

--- a/opentech/apply/home/models.py
+++ b/opentech/apply/home/models.py
@@ -4,6 +4,8 @@ from wagtail.search import index
 
 from django.db import models
 
+from opentech.apply.funds.models import ApplicationBase, LabBase
+
 
 class ApplyHomePage(Page):
     # Only allow creating HomePages at the root level
@@ -19,3 +21,9 @@ class ApplyHomePage(Page):
     content_panels = Page.content_panels + [
         FieldPanel('strapline'),
     ]
+
+    def get_context(self, *args, **kwargs):
+        context = super().get_context(*args, **kwargs)
+        context['open_funds'] = ApplicationBase.objects.order_by_end_date()
+        context['open_labs'] = LabBase.objects.public().live()
+        return context

--- a/opentech/apply/home/templates/apply_home/apply_home_page.html
+++ b/opentech/apply/home/templates/apply_home/apply_home_page.html
@@ -17,7 +17,7 @@
 
     <div class="wrapper wrapper--listings">
     {% for child_page in page.get_children.public.live %}
-        {% include "apply_home/includes/apply_listing.html" with page=child_page %}
+        {% include "apply_home/includes/apply_listing.html" with page=child_page.specific %}
     {% endfor %}
     </div>
 

--- a/opentech/apply/home/templates/apply_home/apply_home_page.html
+++ b/opentech/apply/home/templates/apply_home/apply_home_page.html
@@ -16,8 +16,11 @@
     </div>
 
     <div class="wrapper wrapper--listings">
-    {% for child_page in page.get_children.public.live %}
-        {% include "apply_home/includes/apply_listing.html" with page=child_page.specific %}
+    {% for fund in open_funds %}
+        {% include "apply_home/includes/apply_listing.html" with page=fund.specific %}
+    {% endfor %}
+    {% for lab in open_labs %}
+        {% include "apply_home/includes/apply_listing.html" with page=lab.specific %}
     {% endfor %}
     </div>
 

--- a/opentech/apply/home/templates/apply_home/includes/apply_listing.html
+++ b/opentech/apply/home/templates/apply_home/includes/apply_listing.html
@@ -1,37 +1,24 @@
 {% load wagtailcore_tags %}
 
-{% with details=page.specific.detail.specific %}
-{% if page.specific.open_round %}
+{% with details=page.detail.specific %}
+{% if page.open_round %}
   <div class="listing listing--not-a-link">
       <div>
           <h4 class="listing__title listing__title--link">
-              {% if details.deadline %}
+              {% if page.next_deadline %}
                   <p class="listing__deadline">
                       <svg class="icon icon--calendar icon--small"><use xlink:href="#calendar"></use></svg>
-                      <span>Next deadline: {{ details.deadline|date:"M j, Y" }}</span>
+                      <span>Next deadline: {{ page.next_deadline|date:"M j, Y" }}</span>
                   </p>
               {% endif %}
-              {# details may be None, so be more verbose in the handling of the title #}
-              {% if page.title %}
-                  {% if details %}
-                      <a href="{% pageurl details %}">
-                  {% endif %}
+              {% if details %}
+                  <a href="{% pageurl details %}">
+              {% endif %}
 
-                  {{ page.title }}
+              {{ page.title }}
 
-                  {% if details %}
-                      </a>
-                  {% endif %}
-              {% else %}
-                  {% if details %}
-                      <a href="{% pageurl details %}">
-                  {% endif %}
-
-                  {{ details.listing_title|default:details.title }}
-
-                  {% if details %}
-                      </a>
-                  {% endif %}
+              {% if details %}
+                  </a>
               {% endif %}
           </h4>
 
@@ -40,6 +27,6 @@
           {% endif %}
       </div>
       <a class="listing__button" href="{% pageurl page %}">Apply</a>
-  </div>   
+  </div>
 {% endif %}
 {% endwith %}

--- a/opentech/apply/users/templates/users/account.html
+++ b/opentech/apply/users/templates/users/account.html
@@ -5,8 +5,12 @@
 
 {% block content %}
 <div class="admin-bar">
-    <div class="admin-bar__inner wrapper--search">
+    <div class="admin-bar__inner admin-bar__inner--with-button">
         <h3 class="admin-bar__heading">Welcome {{ user }}</h3>
+        <a href="{% url 'dashboard:dashboard' %}" class="button button--primary button--arrow-pixels-white">
+            Go to dashboard
+            <svg><use xlink:href="#arrow-head-pixels--solid"></use></svg>
+        </a>
     </div>
 </div>
 

--- a/opentech/static_src/src/sass/apply/components/_all-submissions.scss
+++ b/opentech/static_src/src/sass/apply/components/_all-submissions.scss
@@ -164,6 +164,14 @@ $table-breakpoint: 'tablet-landscape';
                 }
             }
 
+            &.reviews_stats {
+                display: none;
+
+                @include media-query($table-breakpoint) {
+                    display: table-cell;
+                }
+            }
+
             // arrow to toggle project info - added via js
             @include media-query($table-breakpoint) {
                 .arrow {
@@ -177,6 +185,19 @@ $table-breakpoint: 'tablet-landscape';
                     &:hover {
                         cursor: pointer;
                     }
+                }
+            }
+
+            > span.mobile-label {
+                width: 90px;
+                display: inline-block;
+
+                &.phase, &.title {
+                    display: none;
+                }
+
+                @include media-query($table-breakpoint) {
+                    display: none;
                 }
             }
         }

--- a/opentech/static_src/src/sass/apply/components/_all-submissions.scss
+++ b/opentech/static_src/src/sass/apply/components/_all-submissions.scss
@@ -167,7 +167,7 @@ $table-breakpoint: 'tablet-landscape';
             // arrow to toggle project info - added via js
             @include media-query($table-breakpoint) {
                 .arrow {
-                    @include triangle(bottom, $color--primary, 6px);
+                    @include triangle(right, $color--primary, 6px);
                     position: relative;
                     display: inline-block;
                     margin-right: 15px;
@@ -197,8 +197,8 @@ $table-breakpoint: 'tablet-landscape';
             }
 
             .arrow {
-                border-top-color: darken($color--dark-blue, 10%);
-                transform: rotate(180deg);
+                border-right-color: darken($color--dark-blue, 10%);
+                transform: rotate(90deg);
             }
         }
     }
@@ -236,4 +236,3 @@ $table-breakpoint: 'tablet-landscape';
         padding: 5px 0 5px 5px;
     }
 }
-

--- a/opentech/static_src/src/sass/apply/components/_button.scss
+++ b/opentech/static_src/src/sass/apply/components/_button.scss
@@ -196,4 +196,16 @@
             border: 1px solid $color--light-blue;
         }
     }
+
+    &--arrow-pixels-white {
+        display: flex;
+        align-items: center;
+
+        svg {
+            width: 10px;
+            height: 14px;
+            margin-left: 10px;
+            fill: $color--white;
+        }
+    }
 }

--- a/opentech/static_src/src/sass/apply/components/_messages.scss
+++ b/opentech/static_src/src/sass/apply/components/_messages.scss
@@ -13,12 +13,12 @@
         padding-right: 35px;
         border: solid 1px;
 
-        &--info {
+        &--info , &--success {
             background: $color--pastel-green;
             border-color: darken($color--pastel-green, 20%);
         }
 
-        &--warning {
+        &--warning, &--error {
             font-weight: bold;
             color: $color--white;
             background: $color--error;

--- a/opentech/static_src/src/sass/apply/components/_table.scss
+++ b/opentech/static_src/src/sass/apply/components/_table.scss
@@ -20,7 +20,7 @@ table {
         }
     }
 
-    // tale rows
+    // table rows
     tr {
         border: 1px solid $color--light-mid-grey;
         transition: box-shadow 0.15s ease;
@@ -62,20 +62,21 @@ table {
 
             &.lead {
                 span {
-                    position: relative;
-                    z-index: 1;
-                    display: block;
-                    padding-right: 5px;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    background: $color--white;
+                    @include media-query($table-breakpoint) {
+                        position: relative;
+                        z-index: 1;
+                        display: block;
+                        padding-right: 5px;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        background: $color--white;
 
-                    &:hover {
-                        display: inline-block;
-                        overflow: visible;
+                        &:hover {
+                            display: inline-block;
+                            overflow: visible;
+                        }
                     }
                 }
-
             }
         }
     }


### PR DESCRIPTION
Collection of smaller fixes grouped together.

**Apply Homepage**

- Confirm ordering of the apply homepage - review previous ticket
- Apply site funds should not rely on public site to show deadline

**General Issues**

- No styling currently for success message - use info styling

**Submissions**

- User id not tracked on the initial revision
- Allow leads to progress the application from More info required
- BUG - Reviewers action - staff remove all AC reviewers when updating staff reviewers

**Submission Listing**
 
- Add labels for fields shown in the mobile view of the submissions listing
- Change the "Reviewers/Outcomes" text in extended view to read "Review outcomes"

**Applicant**

- Add a "go to dashboard" button to the applicant's profile page