### PR TITLE
Remove the username step from the social auth

### DIFF
--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -395,7 +395,6 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_uid',
     'social_core.pipeline.social_auth.auth_allowed',
     'social_core.pipeline.social_auth.social_user',
-    'social_core.pipeline.user.get_username',
     'social_core.pipeline.social_auth.associate_by_email',
     'social_core.pipeline.user.create_user',
     'social_core.pipeline.social_auth.associate_user',


### PR DESCRIPTION
Our user model uses email and doesnt have an username field