### PR TITLE
Add autoDisplay: false to the Google translate widget so the bar only…

### DIFF
--- a/opentech/templates/base.html
+++ b/opentech/templates/base.html
@@ -199,7 +199,7 @@
         <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
         <script type="text/javascript">
             function googleTranslateElementInit() {
-              new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.SIMPLE}, 'google_translate_element');
+              new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.SIMPLE, autoDisplay: false}, 'google_translate_element');
             }
         </script>
         {% block extra_js %}{% endblock %}


### PR DESCRIPTION
… shows for other languages than English.