### PR TITLE
Short circuit the save for the transition

### DIFF
--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -38,21 +38,24 @@ class AccessFormData:
 
     @classmethod
     def stream_file(cls, file):
-        if 'path' in file:
-            file['filename'] = file['name']
-            file['name'] = file['path']
         if isinstance(file, StreamFieldFile):
             return file
         if isinstance(file, File):
             return StreamFieldFile(file, name=file.name, storage=submission_storage)
+
+        # This fixes a backwards compatibility issue with #507
+        # Once every application has been re-saved it should be possible to remove it
+        if 'path' in file:
+            file['filename'] = file['name']
+            file['name'] = file['path']
         return StreamFieldFile(None, name=file['name'], filename=file.get('filename'), storage=submission_storage)
 
     @classmethod
     def process_file(cls, file):
-        try:
-            return cls.stream_file(file)
-        except TypeError:
+        if isinstance(file, list):
             return [cls.stream_file(f) for f in file]
+        else:
+            return cls.stream_file(file)
 
     @classmethod
     def from_db(cls, db, field_names, values):

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -225,7 +225,7 @@ class AddTransitions(models.base.ModelBase):
                 raise PermissionDenied(f'You do not have permission to "{ action }"')
 
             transition(by=user, request=request, **kwargs)
-            self.save()
+            self.save(update_fields=['status'])
 
             self.progress_stage_when_possible(user, request)
 
@@ -474,7 +474,11 @@ class ApplicationSubmission(
                         f.save(folder)
                 self.form_data[field.id] = file
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, update_fields=list(), **kwargs):
+        if update_fields and 'form_data' not in update_fields:
+            # We don't want to use this approach if the user is sending data
+            return super().save(*args, update_fields=update_fields, **kwargs)
+
         if self.is_draft:
             raise ValueError('Cannot save with draft data')
 

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -21,7 +21,7 @@ from opentech.apply.activity.views import (
     DelegatedViewMixin,
 )
 from opentech.apply.activity.messaging import messenger, MESSAGES
-from opentech.apply.funds.workflow import DETERMINATION_OUTCOMES
+from opentech.apply.determinations.views import DeterminationCreateOrUpdateView
 from opentech.apply.review.views import ReviewContextMixin
 from opentech.apply.users.decorators import staff_required
 from opentech.apply.utils.views import DelegateableView, ViewDispatcher
@@ -80,10 +80,9 @@ class ProgressSubmissionView(DelegatedViewMixin, UpdateView):
     def form_valid(self, form):
         action = form.cleaned_data.get('action')
         # Defer to the determination form for any of the determination transitions
-        if action in DETERMINATION_OUTCOMES:
-            return HttpResponseRedirect(reverse_lazy(
-                'apply:submissions:determinations:form',
-                args=(form.instance.id,)) + "?action=" + action)
+        redirect = DeterminationCreateOrUpdateView.should_redirect(self.request, self.object, action)
+        if redirect:
+            return redirect
 
         self.object.perform_transition(action, self.request.user, request=self.request)
         return super().form_valid(form)


### PR DESCRIPTION
This allows us to skip the file handling if we are just updating the status field. Should avoid some of the issues we've been seeing on sending determinations.