### PR TITLE
Make sure the reset url is the correct site from the request

### DIFF
--- a/opentech/apply/users/templates/users/password_reset/email.txt
+++ b/opentech/apply/users/templates/users/password_reset/email.txt
@@ -1,6 +1,6 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
 {% trans "Please follow the link below to reset your password:" %}
-{% if site.root_url %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
 
 {% if user.USERNAME_FIELD != "email" %}
 {% trans "Your username (in case you've forgotten):" %} {{ user.get_username }}

--- a/opentech/apply/users/tests/test_views.py
+++ b/opentech/apply/users/tests/test_views.py
@@ -1,6 +1,8 @@
+from django.core import mail
 from django.test import override_settings, TestCase
 from django.urls import reverse
 
+from opentech.apply.utils.testing.tests import BaseViewTestCase
 from .factories import OAuthUserFactory, StaffFactory, UserFactory
 
 
@@ -44,3 +46,15 @@ class TestStaffProfileView(BaseTestProfielView):
     def test_can_set_slack_name(self):
         response = self.client.get(self.url, follow=True)
         self.assertContains(response, 'Slack name')
+
+
+class TestPasswordReset(BaseViewTestCase):
+    user_factory = UserFactory
+    url_name = 'users:{}'
+    base_view_name = 'password_reset'
+
+    def test_recieves_email(self):
+        response = self.post_page(None, data={'email': self.user.email})
+        self.assertRedirects(response, self.url(None, view_name='password_reset_done'))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('https://testserver/account/password/reset/confirm', mail.outbox[0].body)


### PR DESCRIPTION
This should now correctly pick up the site from the request's origin. Which will always be the apply site.

closes #539 