### PR TITLE
Ensure we don't change the user's name on submission

### DIFF
--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -244,6 +244,12 @@ class TestFormSubmission(TestCase):
         self.assertEqual(ApplicationSubmission.objects.count(), 1)
         self.assertEqual(ApplicationSubmission.objects.first().user, new_user)
 
+    def test_doesnt_mess_with_name(self):
+        full_name = "I have; <a> wei'rd name"
+        self.submit_form(name=full_name)
+        submission = ApplicationSubmission.objects.first()
+        self.assertEqual(submission.user.full_name, full_name)
+
     def test_associated_if_not_new(self):
         self.submit_form()
         self.submit_form()


### PR DESCRIPTION
attempting solution for #543 

Just adding a test, no behaviour change.

Will add more discussion onto the page. 