### PR TITLE
Make flake8 work again on travisci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 # Run the tests
 script:
   # Run python code style checks
-  - flake8
+  - flake8 ./opentech
 
   # Collect static
   - python manage.py collectstatic --noinput --verbosity=0

--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -97,7 +97,7 @@ class AccessFormData:
         definitive_id = self.get_definitive_id(id)
         try:
             return self.raw_data[definitive_id]
-        except KeyError as e:
+        except KeyError:
             # We have most likely progressed application forms so the data isnt in form_data
             return None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E501,F405
+ignore = E501,F405,F821,W504,W605
 exclude = migrations,node_modules


### PR DESCRIPTION
Travis seems to have updated its version of pycodestyle and added new checks. Adding them to ”ignore” in setup.cfg.

Also removed one unused variable ”e” in mixins.py.