### PR TITLE
Allow non responded named fields to be rendered

### DIFF
--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -36,8 +36,13 @@ class AccessFormData:
         data = self.form_data.copy()
         for field_name, field_id in self.named_blocks.items():
             if field_id not in data:
-                response = data[field_name]
-                data[field_id] = response
+                try:
+                    response = data[field_name]
+                except KeyError:
+                    # There was no value supplied for the named field
+                    pass
+                else:
+                    data[field_id] = response
         return data
 
     @classmethod

--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -468,6 +468,13 @@ class TestSubmissionRenderMethods(TestCase):
         answers = submission.render_answers()
         self.assertNotIn(rich_text_label, answers)
 
+    def test_named_blocks_dont_break_if_no_response(self):
+        submission = ApplicationSubmissionFactory()
+        # the user didn't respond
+        del submission.form_data['value']
+        self.assertTrue('value' not in submission.raw_data)
+        self.assertTrue('duration' in submission.raw_data)
+
 
 class TestRequestForPartners(TestCase):
     def test_message_when_no_round(self):


### PR DESCRIPTION
This fixes the issue with applications not showing any submission information. 

This was due to the deserialisation method falling over if it found a missing named block, essentially returning `None` for all responses. (`value` from the look of the live data).

This allows the data to correctly fail silently if a named block is submitted without a value.

A separate question for OTF is whether the value should be not required for the round causing the issues.   

