### PR TITLE
WIP: API spec implementation

### DIFF
--- a/opentech/apply/funds/api_views.py
+++ b/opentech/apply/funds/api_views.py
@@ -1,0 +1,25 @@
+from rest_framework import generics
+from rest_framework import permissions
+from django_filters.rest_framework import DjangoFilterBackend
+
+from .models import ApplicationSubmission
+from .serializers import SubmissionListSerializer, SubmissionDetailSerializer
+from .permissions import IsApplyStaffUser
+
+
+class SubmissionList(generics.ListAPIView):
+    queryset = ApplicationSubmission.objects.all()
+    serializer_class = SubmissionListSerializer
+    permission_classes = (
+        permissions.IsAuthenticated, IsApplyStaffUser,
+    )
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('round', 'status')
+
+
+class SubmissionDetail(generics.RetrieveAPIView):
+    queryset = ApplicationSubmission.objects.all()
+    serializer_class = SubmissionDetailSerializer
+    permission_classes = (
+        permissions.IsAuthenticated, IsApplyStaffUser,
+    )

--- a/opentech/apply/funds/permissions.py
+++ b/opentech/apply/funds/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework import permissions
+
+
+class IsApplyStaffUser(permissions.BasePermission):
+    """
+    Custom permission to only allow OTF Staff or higher
+    """
+
+    def has_permission(self, request, view):
+        return request.user.is_apply_staff
+
+    def has_object_permission(self, request, view, obj):
+        return request.user.is_apply_staff

--- a/opentech/apply/funds/serializers.py
+++ b/opentech/apply/funds/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from .models import ApplicationSubmission
+
+
+class SubmissionListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ApplicationSubmission
+        fields = ('id',)
+
+
+class SubmissionDetailSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ApplicationSubmission
+        fields = ('id', 'title',)

--- a/opentech/apply/funds/urls.py
+++ b/opentech/apply/funds/urls.py
@@ -10,6 +10,7 @@ from .views import (
     SubmissionSealedView,
     SubmissionSearchView,
 )
+from .api_views import SubmissionList, SubmissionDetail
 
 
 revision_urls = ([
@@ -35,8 +36,14 @@ submission_urls = ([
     path('rounds/<int:pk>/', SubmissionsByRound.as_view(), name="by_round"),
 ], 'submissions')
 
+submission_api_urls = ([
+    path('', SubmissionList.as_view(), name='list'),
+    path('<int:pk>/', SubmissionDetail.as_view(), name='detail'),
+], 'submissions-api')
+
 
 urlpatterns = [
     path('submissions/', include(submission_urls)),
+    path('api/submissions/', include(submission_api_urls)),
     path('search/', SubmissionSearchView.as_view(), name="search"),
 ]

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -116,6 +116,7 @@ INSTALLED_APPS = [
     'django_bleach',
     'django_fsm',
     'django_pwned_passwords',
+    'rest_framework',
 
     'hijack',
     'compat',
@@ -604,4 +605,17 @@ WEBPACK_LOADER = {
 # Django countries package provides ISO 3166-1 countries which does not contain Kosovo.
 COUNTRIES_OVERRIDE = {
     'KV': 'Kosovo',
+}
+
+# Rest Framework configuration
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10,
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    )
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django~=2.0.0
-djangorestframework==3.7.4
+djangorestframework==3.9.0
 django-fsm==2.6.0
 wagtail~=2.2.0
 psycopg2==2.7.3.1


### PR DESCRIPTION
link #768 

Initial work: DRF integration (like default authentication), staff permissions and submissions list endpoint.

Example endpoint: `/apply/api/submissions/`. Normal submissions URL is `/apply/submissions/`. It seems better to contain API endpoints under `***/api/***`.