### PR TITLE
adds lvh.me domains to allowed hosts

### DIFF
--- a/opentech/settings/dev.py
+++ b/opentech/settings/dev.py
@@ -8,7 +8,7 @@ SECRET_KEY = 'CHANGEME!!!'
 
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2')
 
-ALLOWED_HOSTS = ['apply.localhost', 'localhost', '127.0.0.1', 'apply.lvh.me', 'lvh.me']
+ALLOWED_HOSTS = ['apply.localhost', 'localhost', '127.0.0.1', 'dev.otf.is', 'dev-apply.otf.is']
 
 BASE_URL = 'http://localhost:8000'
 

--- a/opentech/settings/dev.py
+++ b/opentech/settings/dev.py
@@ -8,7 +8,7 @@ SECRET_KEY = 'CHANGEME!!!'
 
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2')
 
-ALLOWED_HOSTS = ['apply.localhost', 'localhost', '127.0.0.1']
+ALLOWED_HOSTS = ['apply.localhost', 'localhost', '127.0.0.1', 'apply.lvh.me', 'lvh.me']
 
 BASE_URL = 'http://localhost:8000'
 


### PR DESCRIPTION
- Adds `lvh.me` and `apply.lvh.me` domains to `ALLOWED_HOSTS` 

Browsers other than Chrome won't handle `*.localhost` subdomains without modifying hosts files - when browser testing this isn't practical so the addition of these domains will remedy this.