### PR TITLE
Make sure that we can get the distinct column for the jsonfield

### DIFF
--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -61,7 +61,8 @@ class JSONOrderable(models.QuerySet):
                 field = field[1:]
             else:
                 descending = False
-            return OrderBy(RawSQL(f'LOWER({self.json_field}->>%s)', (field,)), descending=descending, nulls_last=True)
+            db_table = self.model._meta.db_table
+            return OrderBy(RawSQL(f'LOWER({db_table}.{self.json_field}->>%s)', (field,)), descending=descending, nulls_last=True)
 
         field_ordering = [build_json_order_by(field) for field in field_names]
         return super().order_by(*field_ordering)


### PR DESCRIPTION
this fixes the sentry issue found here: https://sentry.io/otf/otf-webapp-test/issues/844604394/

The query was generating too many references to form_data and getting confused. This makes the table to use explicit.

Most likely impacted the testing of #791 