### PR TITLE
Remove the public search and newsletter urls from the apply site

### DIFF
--- a/opentech/apply/urls.py
+++ b/opentech/apply/urls.py
@@ -3,7 +3,7 @@ from django.urls import include, path
 from .users import urls as users_urls
 from .dashboard import urls as dashboard_urls
 
-from opentech.urls import urlpatterns as base_urlpatterns
+from opentech.urls import base_urlpatterns
 
 
 urlpatterns = [

--- a/opentech/apply/urls.py
+++ b/opentech/apply/urls.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.urls import include, path
 
+from .utils import views
 from .users import urls as users_urls
 from .dashboard import urls as dashboard_urls
 
@@ -14,4 +16,13 @@ urlpatterns = [
     path('hijack/', include('hijack.urls', 'hijack')),
 ]
 
+if settings.DEBUG:
+    urlpatterns += [
+        # Add views for testing 404 and 500 templates
+        path('test404/', views.page_not_found),
+    ]
+
 urlpatterns += base_urlpatterns
+
+
+handler404 = 'opentech.apply.utils.views.page_not_found'

--- a/opentech/apply/utils/__init__.py
+++ b/opentech/apply/utils/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'opentech.apply.utils.app.UtilsConfig'

--- a/opentech/apply/utils/app.py
+++ b/opentech/apply/utils/app.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class UtilsConfig(AppConfig):
+    name = 'opentech.apply.utils'
+    label = 'apply_utils'

--- a/opentech/apply/utils/templates/apply/404.html
+++ b/opentech/apply/utils/templates/apply/404.html
@@ -1,0 +1,13 @@
+{% extends "base-apply.html" %}
+{% load wagtailcore_tags wagtailsettings_tags %}
+
+{% block title %}{{ settings.utils.SystemMessagesSettings.title_404 }}{% endblock %}
+
+{% block body_class %}template-404{% endblock %}
+
+{% block content %}
+<div class="wrapper wrapper--small wrapper--inner-space-large">
+    <h1>{{ settings.utils.SystemMessagesSettings.title_404 }}</h1>
+    {{ settings.utils.SystemMessagesSettings.body_404|richtext }}
+</div>
+{% endblock %}

--- a/opentech/apply/utils/views.py
+++ b/opentech/apply/utils/views.py
@@ -1,8 +1,13 @@
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
+from django.views import defaults
 from django.views.generic import DetailView, View
 from django.views.generic.detail import SingleObjectTemplateResponseMixin
 from django.views.generic.edit import ModelFormMixin, ProcessFormView
+
+
+def page_not_found(request, exception=None, template_name='apply/404.html'):
+    return defaults.page_not_found(request, exception, template_name)
 
 
 @method_decorator(login_required, name='dispatch')

--- a/opentech/apply/utils/views.py
+++ b/opentech/apply/utils/views.py
@@ -8,7 +8,7 @@ from django.views.generic.edit import ModelFormMixin, ProcessFormView
 
 def page_not_found(request, exception=None, template_name='apply/404.html'):
     if not request.user.is_authenticated:
-        template_name='404.html'
+        template_name = '404.html'
     return defaults.page_not_found(request, exception, template_name)
 
 

--- a/opentech/apply/utils/views.py
+++ b/opentech/apply/utils/views.py
@@ -7,6 +7,8 @@ from django.views.generic.edit import ModelFormMixin, ProcessFormView
 
 
 def page_not_found(request, exception=None, template_name='apply/404.html'):
+    if not request.user.is_authenticated:
+        template_name='404.html'
     return defaults.page_not_found(request, exception, template_name)
 
 

--- a/opentech/public/mailchimp/templates/mailchimp/newsletter_signup.html
+++ b/opentech/public/mailchimp/templates/mailchimp/newsletter_signup.html
@@ -1,5 +1,5 @@
 <h4>Get the latest internet freedom news</h4>
-<form class="form" action="{% url "newsletter:subscribe" %}" method="post">
+<form class="form" action="{{ PUBLIC_SITE.root_url }}{% url "newsletter:subscribe" %}" method="post">
     <div>
         {% for field in newsletter_form %}
         <label for="{{ field.id_for_label }}"{% if field.field.required %} required{% endif %}>

--- a/opentech/public/search/views.py
+++ b/opentech/public/search/views.py
@@ -1,11 +1,17 @@
 from django.conf import settings
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.http import Http404
 from django.shortcuts import render
 from wagtail.core.models import Page
 from wagtail.search.models import Query
 
+from opentech.public.home.models import HomePage
+
 
 def search(request):
+    if request.site != HomePage.objects.first().get_site():
+        raise Http404
+
     search_query = request.GET.get('query', None)
     page = request.GET.get('page', 1)
 

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     'opentech.apply.review',
     'opentech.apply.determinations',
     'opentech.apply.stream_forms',
+    'opentech.apply.utils',
 
     'opentech.public.funds',
     'opentech.public.home',

--- a/opentech/templates/base.html
+++ b/opentech/templates/base.html
@@ -129,7 +129,7 @@
                 </div>
 
                 <div class="header__search">
-                    <form action="{% url 'search' %}" method="get" role="search" class="form form--header-search-desktop">
+                    <form action="{{ PUBLIC_SITE.root_url }}{% url 'search' %}" method="get" role="search" class="form form--header-search-desktop">
                         <button class="button" type="submit" aria-label="Search">
                             <svg class="icon icon--magnifying-glass icon--search"><use xlink:href="#magnifying-glass"></use></svg>
                         </button>

--- a/opentech/urls.py
+++ b/opentech/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path('documents/', include(wagtaildocs_urls)),
     path('sitemap.xml', sitemap),
     path('', include((user_urls, 'users_public'))),
+    path('', include(public_urls)),
     path('', include('social_django.urls', namespace='social')),
     path('tinymce/', include('tinymce.urls')),
     path('select2/', include('django_select2.urls')),
@@ -75,11 +76,3 @@ if settings.DEBUG and settings.DEBUGTOOLBAR:
 
 
 base_urlpatterns = [*urlpatterns]
-
-
-# Add in URLs only available to the public site
-# Place before the wagtail urls without mutating the object
-urlpatterns.insert(
-    -1,
-    *apply_cache_control(path('', include(public_urls)))
-)


### PR DESCRIPTION
@emullaney Testing highlighted this issue where `/search/` from the public site was appearing on the apply site.

~~I've tweaked the url conf to prevent this.~~

Change of plan. I've 404'ed the search view on apply and directing all uses of serach and newsletter to the public site. I've also made a custom 404 for the apply site which varies the base template based on if you are logged in or not.

We use two URL confs. One for each of the apply and public. They are essentially the same base urls, but it allows us to resolve login urls on the public site and removes all apply urls from the public site.

This is handled in middleware based on the host name of the site being the apply site as configured in the Wagtail admin.

