### PR TITLE
ensure fetch works in safari

### DIFF
--- a/opentech/static_src/src/app/src/api/utils.js
+++ b/opentech/static_src/src/app/src/api/utils.js
@@ -15,5 +15,6 @@ export async function apiFetch(path, method = 'GET', params, options) {
         ...options,
         method,
         mode: 'same-origin',
+        credentials: 'include'
     });
 }


### PR DESCRIPTION
adds credentials to fetch so the cookie is set in the headers and the fetch works successfully in safari