### PR TITLE
overlay scroll bars in detail view

### DIFF
--- a/opentech/static_src/src/app/src/components/DetailView/style.scss
+++ b/opentech/static_src/src/app/src/components/DetailView/style.scss
@@ -1,5 +1,6 @@
 .detail-view {
     margin: 0 -20px;
+    overflow-y: overlay;
 
     @include media-query(tablet-landscape) {
         display: grid;


### PR DESCRIPTION
make the detail view scrollbars appear as an overlay so it doesn't affect the width of the content