### PR TITLE
any filters not in list should cause filters to show

### DIFF
--- a/opentech/static_src/src/javascript/apply/submission-filters.js
+++ b/opentech/static_src/src/javascript/apply/submission-filters.js
@@ -23,7 +23,7 @@
     // check if the page has a query string and keep filters open if so on desktop
     const minimumNumberParams = persistedParams.reduce(
         (count, param) => count + urlParams.has(param) ? 1 : 0,
-        1
+        0
     );
 
     if ([...urlParams].length > minimumNumberParams && $(window).width() > 1024) {


### PR DESCRIPTION
@chris-lawton 

This means that the filters show correctly whenever any filter is selected that isn't `query` or `sort`