### PR TITLE
Feature/810: Rounds block: Dashboard changes

### DIFF
--- a/opentech/apply/dashboard/templates/dashboard/dashboard.html
+++ b/opentech/apply/dashboard/templates/dashboard/dashboard.html
@@ -18,6 +18,11 @@
 </div>
 <div class="wrapper wrapper--large wrapper--inner-space-medium">
         <div class="wrapper wrapper--large wrapper--inner-space-medium">
+
+            {% if closed_rounds or open_rounds %}
+                {% include "funds/includes/round-block.html" with closed_rounds=closed_rounds open_rounds=open_rounds title=rounds_title %}
+            {% endif %}
+
             <h3>Applications to review</h3>
             {% if in_review.data %}
                 {% render_table in_review %}
@@ -30,4 +35,5 @@
 
 {% block extra_js %}
     <script src="{% static 'js/apply/submission-tooltips.js' %}"></script>
+    <script src="{% static 'js/apply/tabs.js' %}"></script>
 {% endblock %}

--- a/opentech/apply/dashboard/views.py
+++ b/opentech/apply/dashboard/views.py
@@ -3,7 +3,7 @@ from django.views.generic import TemplateView
 from django_tables2 import RequestConfig
 from django_tables2.views import SingleTableView
 
-from opentech.apply.funds.models import ApplicationSubmission
+from opentech.apply.funds.models import ApplicationSubmission, RoundsAndLabs
 from opentech.apply.funds.tables import SubmissionsTable, AdminSubmissionsTable
 from opentech.apply.utils.views import ViewDispatcher
 
@@ -15,9 +15,21 @@ class AdminDashboardView(TemplateView):
 
         in_review = SubmissionsTable(qs.in_review_for(request.user), prefix='in-review-')
         RequestConfig(request, paginate={'per_page': 10}).configure(in_review)
+        base_query = RoundsAndLabs.objects.with_progress().active().order_by('-end_date')
+        base_query = base_query.by_lead(request.user)
+        open_rounds = base_query.open()[:6]
+        open_query = '?round_state=open'
+        closed_rounds = base_query.closed()[:6]
+        closed_query = '?round_state=closed'
+        rounds_title = 'Your rounds and labs'
 
         return render(request, 'dashboard/dashboard.html', {
             'in_review': in_review,
+            'open_rounds': open_rounds,
+            'open_query': open_query,
+            'closed_rounds': closed_rounds,
+            'closed_query': closed_query,
+            'rounds_title': rounds_title,
         })
 
 

--- a/opentech/apply/funds/models/applications.py
+++ b/opentech/apply/funds/models/applications.py
@@ -345,6 +345,9 @@ class RoundsAndLabsQueryset(PageQuerySet):
     def closed(self):
         return self.filter(end_date__lt=date.today())
 
+    def by_lead(self, user):
+        return self.filter(lead_pk=user.pk)
+
 
 class RoundsAndLabsProgressQueryset(RoundsAndLabsQueryset):
     def active(self):
@@ -367,6 +370,10 @@ class RoundsAndLabsManager(PageManager):
             end_date=F('roundbase__end_date'),
             parent_path=Left(F('path'), Length('path') - ApplicationBase.steplen, output_field=CharField()),
             fund=Subquery(funds.values('title')[:1]),
+            lead_pk=Coalesce(
+                F('roundbase__lead__pk'),
+                F('labbase__lead__pk'),
+            ),
         )
 
     def with_progress(self):
@@ -405,6 +412,9 @@ class RoundsAndLabsManager(PageManager):
 
     def new(self):
         return self.get_queryset().new()
+
+    def by_lead(self, user):
+        return self.get_queryset().by_lead(user)
 
 
 class RoundsAndLabs(Page):

--- a/opentech/apply/funds/templates/funds/includes/round-block.html
+++ b/opentech/apply/funds/templates/funds/includes/round-block.html
@@ -1,6 +1,6 @@
 <div class="wrapper wrapper--bottom-space">
     <section class="section section--with-options">
-        <h4 class="heading heading--normal heading--no-margin">All Rounds and Labs</h4>
+        <h4 class="heading heading--normal heading--no-margin">Your Rounds and Labs</h4>
         <div class="js-tabs">
             <a class="tab__item tab__item--alt" href="#closed-rounds" data-tab="tab-1">Closed</a>
             <a class="tab__item tab__item--alt" href="#open-rounds" data-tab="tab-2">Open</a>

--- a/opentech/apply/funds/templates/funds/includes/round-block.html
+++ b/opentech/apply/funds/templates/funds/includes/round-block.html
@@ -1,6 +1,6 @@
 <div class="wrapper wrapper--bottom-space">
     <section class="section section--with-options">
-        <h4 class="heading heading--normal heading--no-margin">Your Rounds and Labs</h4>
+        <h4 class="heading heading--normal heading--no-margin">{{ title }}</h4>
         <div class="js-tabs">
             <a class="tab__item tab__item--alt" href="#closed-rounds" data-tab="tab-1">Closed</a>
             <a class="tab__item tab__item--alt" href="#open-rounds" data-tab="tab-2">Open</a>

--- a/opentech/apply/funds/templates/funds/submissions.html
+++ b/opentech/apply/funds/templates/funds/submissions.html
@@ -16,7 +16,7 @@
 <div class="wrapper wrapper--large wrapper--inner-space-medium">
 
     {% if closed_rounds or open_rounds %}
-        {% include "funds/includes/round-block.html" with closed_rounds=closed_rounds open_rounds=open_rounds %}
+        {% include "funds/includes/round-block.html" with closed_rounds=closed_rounds open_rounds=open_rounds title=rounds_title %}
     {% endif %}
 
     {% block table %}

--- a/opentech/apply/funds/templates/funds/submissions.html
+++ b/opentech/apply/funds/templates/funds/submissions.html
@@ -14,6 +14,11 @@
 </div>
 
 <div class="wrapper wrapper--large wrapper--inner-space-medium">
+
+    {% if closed_rounds or open_rounds %}
+        {% include "funds/includes/round-block.html" with closed_rounds=closed_rounds open_rounds=open_rounds %}
+    {% endif %}
+
     {% block table %}
         {{ block.super }}
     {% endblock %}

--- a/opentech/apply/funds/tests/models/test_roundsandlabs.py
+++ b/opentech/apply/funds/tests/models/test_roundsandlabs.py
@@ -77,6 +77,7 @@ class BaseRoundsAndLabTestCase:
         self.assertEqual(qs_all.count(), 2)
         self.assertEqual(qs_by_lead.count(), 1)
         self.assertEqual(fetched_obj.lead, obj.lead.full_name)
+        self.assertNotEqual(round_other_lead.title, fetched_obj.title)
 
 
 class TestForLab(BaseRoundsAndLabTestCase, TestCase):

--- a/opentech/apply/funds/tests/models/test_roundsandlabs.py
+++ b/opentech/apply/funds/tests/models/test_roundsandlabs.py
@@ -67,6 +67,17 @@ class BaseRoundsAndLabTestCase:
         self.assertEqual(fetched_obj, obj)
         self.assertFalse(base_qs.active().exists())
 
+    def test_by_lead(self):
+        obj = self.base_factory()
+        # Create an additional round which will create a new staff lead
+        round_other_lead = RoundFactory()
+        qs_all = RoundsAndLabs.objects.with_progress()
+        qs_by_lead = qs_all.by_lead(obj.lead)
+        fetched_obj = qs_by_lead.first()
+        self.assertEqual(qs_all.count(), 2)
+        self.assertEqual(qs_by_lead.count(), 1)
+        self.assertEqual(fetched_obj.lead, obj.lead.full_name)
+
 
 class TestForLab(BaseRoundsAndLabTestCase, TestCase):
     base_factory = LabFactory

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -89,24 +89,21 @@ class SubmissionOverviewView(AllActivityContextMixin, BaseAdminSubmissionsTable)
         return super().get_table_data().order_by(F('last_update').desc(nulls_last=True))[:5]
 
     def get_context_data(self, **kwargs):
-        # For OTF staff, display rounds/labs where user is the lead
-        if self.request.user.is_staff:
-            base_query = RoundsAndLabs.objects.with_progress().active().order_by('-end_date')
-            base_query = base_query.by_lead(self.request.user)
-            open_rounds = base_query.open()[:6]
-            open_query = '?round_state=open'
-            closed_rounds = base_query.closed()[:6]
-            closed_query = '?round_state=closed'
+        base_query = RoundsAndLabs.objects.with_progress().active().order_by('-end_date')
+        open_rounds = base_query.open()[:6]
+        open_query = '?round_state=open'
+        closed_rounds = base_query.closed()[:6]
+        closed_query = '?round_state=closed'
+        rounds_title = 'All Rounds and Labs'
 
-            return super().get_context_data(
-                open_rounds=open_rounds,
-                open_query=open_query,
-                closed_rounds=closed_rounds,
-                closed_query=closed_query,
-                **kwargs,
-            )
-        else:
-            return super().get_context_data(**kwargs)
+        return super().get_context_data(
+            open_rounds=open_rounds,
+            open_query=open_query,
+            closed_rounds=closed_rounds,
+            closed_query=closed_query,
+            rounds_title=rounds_title,
+            **kwargs,
+        )
 
 
 class SubmissionListView(AllActivityContextMixin, BaseAdminSubmissionsTable):

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -89,19 +89,24 @@ class SubmissionOverviewView(AllActivityContextMixin, BaseAdminSubmissionsTable)
         return super().get_table_data().order_by(F('last_update').desc(nulls_last=True))[:5]
 
     def get_context_data(self, **kwargs):
-        base_query = RoundsAndLabs.objects.with_progress().order_by('end_date')
-        open_rounds = base_query.open()[:6]
-        open_query = '?round_state=open'
-        closed_rounds = base_query.closed()[:6]
-        closed_query = '?round_state=closed'
+        # For OTF staff, display rounds/labs where user is the lead
+        if self.request.user.is_staff:
+            base_query = RoundsAndLabs.objects.with_progress().active().order_by('-end_date')
+            base_query = base_query.by_lead(self.request.user)
+            open_rounds = base_query.open()[:6]
+            open_query = '?round_state=open'
+            closed_rounds = base_query.closed()[:6]
+            closed_query = '?round_state=closed'
 
-        return super().get_context_data(
-            open_rounds=open_rounds,
-            open_query=open_query,
-            closed_rounds=closed_rounds,
-            closed_query=closed_query,
-            **kwargs,
-        )
+            return super().get_context_data(
+                open_rounds=open_rounds,
+                open_query=open_query,
+                closed_rounds=closed_rounds,
+                closed_query=closed_query,
+                **kwargs,
+            )
+        else:
+            return super().get_context_data(**kwargs)
 
 
 class SubmissionListView(AllActivityContextMixin, BaseAdminSubmissionsTable):


### PR DESCRIPTION
- Block is title "Your rounds and labs"
- Only displayed for OTF staff where user is the 'Round lead' (does not display for other user types)
- If no Round/Labs then block does not display (this was done on #822 and copied here)
- Unit test for `by_lead` filter method