### PR TITLE
Bugfix/806 activity templating fails

### DIFF
--- a/opentech/apply/activity/messaging.py
+++ b/opentech/apply/activity/messaging.py
@@ -189,7 +189,8 @@ class ActivityAdapter(AdapterBase):
         visibility = kwargs.get('visibility', PUBLIC)
 
         related = kwargs['related']
-        if isinstance(related, models.Model):
+        has_correct_fields = all(hasattr(related, attr) for attr in ['author', 'submission', 'get_absolute_url'])
+        if has_correct_fields and isinstance(related, models.Model):
             related_object = related
         else:
             related_object = None

--- a/opentech/apply/activity/tests/test_messaging.py
+++ b/opentech/apply/activity/tests/test_messaging.py
@@ -11,6 +11,7 @@ from django.contrib.messages import get_messages
 
 from opentech.apply.utils.testing import make_request
 from opentech.apply.funds.tests.factories import ApplicationSubmissionFactory
+from opentech.apply.review.tests.factories import ReviewFactory
 from opentech.apply.users.tests.factories import ReviewerFactory, UserFactory
 
 from ..models import Activity, Event, Message, INTERNAL, PUBLIC
@@ -266,6 +267,21 @@ class TestActivityAdapter(TestCase):
 
         self.assertIn(submission.phase.display_name, message)
         self.assertIn(old_phase.display_name, message)
+
+    def test_lead_not_saved_on_activity(self):
+        submission = ApplicationSubmissionFactory()
+        user = UserFactory()
+        self.adapter.send_message('a message', user=user, submission=submission, related=user)
+        activity = Activity.objects.first()
+        self.assertEqual(activity.related_object, None)
+
+    def test_review_saved_on_activtiy(self):
+        submission = ApplicationSubmissionFactory()
+        user = UserFactory()
+        review = ReviewFactory(submission=submission)
+        self.adapter.send_message('a message', user=user, submission=submission, related=review)
+        activity = Activity.objects.first()
+        self.assertEqual(activity.related_object, review)
 
 
 class TestSlackAdapter(AdapterMixin, TestCase):

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -335,6 +335,11 @@ LOGGING = {
             'level': 'INFO',
             'propagate': False,
         },
+        'django': {
+            'handlers': ['console', 'sentry'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
         'django.request': {
             'handlers': ['console', 'sentry'],
             'level': 'WARNING',


### PR DESCRIPTION
Due to the addition of a prefetch in `activity/views.py` the templates are now falling over when it comes to render the activity feed list.

Previously this was just failing silently when trying to call `get_absolute_url` in the template, but the prefetch causes an error higher up the stack. 

I've also added in default logging for templates so that we should get this information in sentry now rather than the console.

@frjo FYI logging above. We will also need to run the following code on prod once we have deployed it.

`Activity.objects.filter(content_type=ContentType.objects.get(model='user')).update(content_type=None, object_id=None)`