### PR TITLE
Display errors and password rules on password reset form

### DIFF
--- a/opentech/apply/users/templates/users/password_reset/confirm.html
+++ b/opentech/apply/users/templates/users/password_reset/confirm.html
@@ -4,10 +4,31 @@
 {% block page_title %}Set your new password{% endblock %}
 {% block content %}
 <div class="wrapper wrapper--small wrapper--bottom-space">
-    <form class="form form--with-p-tags" method="post" novalidate>
+    <form class="form" method="post" novalidate>
+        {% if form.non_field_errors %}
+            <ul class="errorlist">
+                {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+
+        {% if form.errors %}
+            <ul class="errorlist">
+                {% blocktrans count counter=form.errors.items|length %}
+                <li>Please correct the error below.</li>
+                {% plural %}
+                <li>Please correct the errors below.</li>
+                {% endblocktrans %}
+            </ul>
+        {% endif %}
+
         {% csrf_token %}
-        <p>{{ form.new_password1.label_tag }} {{ form.new_password1 }}</p>
-        <p>{{ form.new_password2.label_tag }} {{ form.new_password2 }}</p>
+
+        {% for field in form %}
+            {% include "forms/includes/field.html" %}
+        {% endfor %}
+
         <button class="link link--button-secondary" type="submit">{% trans 'Reset password' %}</button>
     </form>
 </div>


### PR DESCRIPTION
The password reset form was not displaying any errors making it hard for users to understand why the form did not submit.

<strike>When a user access a valid activation url their account are directly set to active and they are logged in. They are then redirected to a form where they should set a password.

For some reason many users simply skip this step and they end up with an active account with no password. Accounts with no password can not use the password reset form.

By using the "set_unusable_password()" to set a password in the first step users can at least use the password reset form if they skip creating a password for their account upon activation.

I have now set an unusable password on all active accounts with empty password as well.</strike>

~~~~
from django.contrib.auth import get_user_model
User = get_user_model()
users = User.objects.filter(password='', is_active=True).all()
for user in users:
	user.set_unusable_password()
	user.save()
~~~~

Since set_unusable_password does not allow the use of the password reset feature after all I have set a long random passord on the affected accounts

~~~~
from django.utils.crypto import get_random_string
from django.contrib.auth import get_user_model
User = get_user_model()
users = User.objects.filter(password__startswith='!', is_active=True).all()
for user in users:
        new_pass = get_random_string(length=32)
	user.set_password(new_pass)
	user.save()
~~~~

Old:

![password_reset_old](https://user-images.githubusercontent.com/191392/51600847-35d49d00-1f03-11e9-95c0-255bc6a8dbeb.png)

New:

![password_reset_new](https://user-images.githubusercontent.com/191392/51600846-35d49d00-1f03-11e9-892d-03d19b1858fa.png)
