### PR TITLE
Updading social_auth_app_django to 3.x to handle new Google API for o…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ responses==0.9.0
 
 flake8
 
-social_auth_app_django==2.1.0
+social_auth_app_django==3.1.0
 django-tables2==1.21.1
 django-filter==1.1.0
 django_select2==6.0.1


### PR DESCRIPTION
…auth2. The Google+ API is going away.

@todd-dembrey  I have set up new Authentication apps on Google as well but we need to switch to them at the same time as we update the social_auth_app_django package.

We should test this on test first to make sure I got all the parts right. How and when do we do this? The Google+ API is going away  by March 7, 2019 *but* will "intermittently fail as early as January 28, 2019" according to Google.