### PR TITLE
Exclude non-text answers like attachment from compare revisions

### DIFF
--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -3,7 +3,9 @@ from django.utils.text import mark_safe
 from django.core.files import File
 from django.core.files.storage import get_storage_class
 
-from opentech.apply.stream_forms.blocks import FormFieldBlock
+from opentech.apply.stream_forms.blocks import (
+    FileFieldBlock, FormFieldBlock, ImageFieldBlock, MultiFileFieldBlock
+)
 from opentech.apply.utils.blocks import SingleIncludeMixin
 
 from opentech.apply.stream_forms.blocks import UploadableMediaBlock
@@ -113,6 +115,14 @@ class AccessFormData:
                 yield field_id
 
     @property
+    def question_text_field_ids(self):
+        for field_id, field in self.fields.items():
+            if isinstance(field.block, (FileFieldBlock, ImageFieldBlock, MultiFileFieldBlock)):
+                pass
+            elif isinstance(field.block, FormFieldBlock):
+                yield field_id
+
+    @property
     def raw_fields(self):
         # Field ids to field class mapping - similar to raw_data
         return {
@@ -166,6 +176,14 @@ class AccessFormData:
         return [
             self.render_answer(field_id, include_question=True)
             for field_id in self.normal_blocks
+        ]
+
+    def render_text_blocks_answers(self):
+        # Returns a list of the rendered answers of type text
+        return [
+            self.render_answer(field_id, include_question=True)
+            for field_id in self.question_text_field_ids
+            if field_id not in self.named_blocks
         ]
 
     def output_answers(self):

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -462,11 +462,11 @@ class RevisionCompareView(DetailView):
 
     def compare_revisions(self, from_data, to_data):
         self.object.form_data = from_data.form_data
-        from_fields = self.object.render_answers()
+        from_rendered_text_fields = self.object.render_text_blocks_answers()
         from_required = self.render_required()
 
         self.object.form_data = to_data.form_data
-        to_fields = self.object.render_answers()
+        to_rendered_text_fields = self.object.render_text_blocks_answers()
         to_required = self.render_required()
 
         # Compare all the required fields
@@ -478,12 +478,12 @@ class RevisionCompareView(DetailView):
             setattr(self.object, 'get_{}_display'.format(field), diff)
 
         # Compare all the answers
-        diffed_answers = [
+        diffed_text_fields_answers = [
             compare(*fields, should_bleach=False)
-            for fields in zip(from_fields, to_fields)
+            for fields in zip(from_rendered_text_fields, to_rendered_text_fields)
         ]
 
-        self.object.output_answers = mark_safe(''.join(diffed_answers))
+        self.object.output_answers = mark_safe(''.join(diffed_text_fields_answers))
 
     def render_required(self):
         return [


### PR DESCRIPTION
Link #749 

@frjo The compare revisions code currently create comparisons by checking the diff in rendered HTML. Therefore when a submission has an attachment it compares only the output HTML of the file field, not the actual file. Comparing HTML generates broken HTML for file like 

```html
<a class="link link--download" href="/media/submission/5/9702febd-53c6-4999-82f8-1cdedbe78f1f/<span class="diff diff__added">contracts_cQrOe9H.csv">
    <div></span><span class="diff diff__deleted">test_document.docx">
    <div></span>
```

Revisions compare [code](https://github.com/OpenTechFund/opentech.fund/blob/master/opentech/apply/funds/differ.py#L22) need updates to handle non-text answers like an image and also display their differences. Images changes can show an old image and a new image. We currently display text-based differences only. The PR removed the non-text fields from comparisons for a while until there is a separate issue to handle non-text fields.

```html
------------ file 1 Output--------------

<section>
    <h4>Upload</h4>

        <div class="wrapper">
            <a class="link link--download" href="/media/submission/5/9702febd-53c6-4999-82f8-1cdedbe78f1f/test_document.docx">
    <div>
        <svg><use xlink:href="#file"></use></svg>
        <span>test_document.docx</span>
    </div>
    <svg><use xlink:href="#download"></use></svg>
</a>

        </div>

</section>

--------------File 2 Output--------------

<section>
    <h4>Upload</h4>

        <div class="wrapper">
            <a class="link link--download" href="/media/submission/5/9702febd-53c6-4999-82f8-1cdedbe78f1f/contracts_cQrOe9H.csv">
    <div>
        <svg><use xlink:href="#file"></use></svg>
        <span>contracts.csv</span>
    </div>
    <svg><use xlink:href="#download"></use></svg>
</a>

        </div>

</section>


------------ Compared HTML using difflib -------------

<section>
    <h4>Upload</h4>

        <div class="wrapper">
            <a class="link link--download" href="/media/submission/5/9702febd-53c6-4999-82f8-1cdedbe78f1f/<span class="diff diff__added">contracts_cQrOe9H.csv">
    <div></span><span class="diff diff__deleted">test_document.docx">
    <div></span>
        <svg><use xlink:href="#file"></use></svg>
        <span><span class="diff diff__added">contracts.csv</span><span class="diff diff__deleted">test_document.docx</span></span>
    </div>
    <svg><use xlink:href="#download"></use></svg>
</a>

        </div>

</section>

```