### PR TITLE
upgrade to redis 3.0 compatible django redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ dj-database-url==0.5.0
 django-basic-auth-ip-whitelist==0.2.1
 django-heroku==0.3.1
 django-pwned-passwords==2.0.0
-django-redis==4.9.0
+django-redis==4.10.0
 django-referrer-policy==1.0
 whitenoise==4.0
 gunicorn==19.9.0


### PR DESCRIPTION
@frjo 

It looks like the changes to the python version have triggered an issue with django/redis compatibility.

django-redis 4.10.0 works correctly with redis 3.0