### PR TITLE
Bugfix/996 correctly serialize category

### DIFF
--- a/opentech/apply/stream_forms/blocks.py
+++ b/opentech/apply/stream_forms/blocks.py
@@ -215,6 +215,10 @@ class CheckboxesFieldBlock(OptionalFormFieldBlock):
         ]
         return kwargs
 
+    def prepare_data(self, value, data, serialize=False):
+        base_prepare = super().prepare_data
+        return [base_prepare(value, item, serialize) for item in data]
+
     def get_searchable_content(self, value, data):
         return data
 

--- a/opentech/apply/stream_forms/blocks.py
+++ b/opentech/apply/stream_forms/blocks.py
@@ -37,9 +37,11 @@ class FormFieldBlock(StructBlock):
         return self.widget
 
     def get_field_kwargs(self, struct_value):
-        kwargs = {'label': struct_value['field_label'],
-                  'help_text': struct_value['help_text'],
-                  'required': struct_value.get('required', False)}
+        kwargs = {
+            'label': struct_value['field_label'],
+            'help_text': struct_value['help_text'],
+            'required': struct_value.get('required', False)
+        }
         if 'default_value' in struct_value:
             kwargs['initial'] = struct_value['default_value']
         form_widget = self.get_widget(struct_value)
@@ -173,10 +175,11 @@ class RadioButtonsFieldBlock(OptionalFormFieldBlock):
         icon = 'radio-empty'
 
     def get_field_kwargs(self, struct_value):
-        kwargs = super(RadioButtonsFieldBlock,
-                       self).get_field_kwargs(struct_value)
-        kwargs['choices'] = [(choice, choice)
-                             for choice in struct_value['choices']]
+        kwargs = super().get_field_kwargs(struct_value)
+        kwargs['choices'] = [
+            (choice, choice)
+            for choice in struct_value['choices']
+        ]
         return kwargs
 
 
@@ -188,8 +191,7 @@ class DropdownFieldBlock(RadioButtonsFieldBlock):
         icon = 'arrow-down-big'
 
     def get_field_kwargs(self, struct_value):
-        kwargs = super(DropdownFieldBlock,
-                       self).get_field_kwargs(struct_value)
+        kwargs = super().get_field_kwargs(struct_value)
         kwargs['choices'].insert(0, BLANK_CHOICE_DASH[0])
         return kwargs
 
@@ -206,10 +208,11 @@ class CheckboxesFieldBlock(OptionalFormFieldBlock):
         template = 'stream_forms/render_list_field.html'
 
     def get_field_kwargs(self, struct_value):
-        kwargs = super(CheckboxesFieldBlock,
-                       self).get_field_kwargs(struct_value)
-        kwargs['choices'] = [(choice, choice)
-                             for choice in struct_value['checkboxes']]
+        kwargs = super().get_field_kwargs(struct_value)
+        kwargs['choices'] = [
+            (choice, choice)
+            for choice in struct_value['checkboxes']
+        ]
         return kwargs
 
     def get_searchable_content(self, value, data):

--- a/opentech/apply/stream_forms/blocks.py
+++ b/opentech/apply/stream_forms/blocks.py
@@ -52,8 +52,9 @@ class FormFieldBlock(StructBlock):
         return self.get_field_class(struct_value)(**field_kwargs)
 
     def serialize(self, value, context):
+        field_kwargs = self.get_field_kwargs(value)
         return {
-            'question': value['field_label'],
+            'question': field_kwargs['label'],
             'answer': context.get('data'),
             'type': self.name,
         }

--- a/opentech/static_src/src/app/src/components/SubmissionDisplay/answers.js
+++ b/opentech/static_src/src/app/src/components/SubmissionDisplay/answers.js
@@ -71,6 +71,7 @@ const answerTypes = {
     'radios': BasicAnswer,
 
     // SPECIAL
+    'checkboxes': BasicListAnswer,
     'rich_text': RichTextAnswer,
     'address': AddressAnswer,
     'category': BasicListAnswer,


### PR DESCRIPTION
This fixes #996 which raises several issues.

* Correctly return the question if it is not defined by the label
* Serialize checkboxes answers as an array
* Render Checkboxes answers as an `<li>`

* Tidy up some code that was old style super.
