### PR TITLE
Handle empty single field field.

### DIFF
--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -49,6 +49,8 @@ class AccessFormData:
 
     @classmethod
     def stream_file(cls, file):
+        if not file:
+            return []
         if isinstance(file, StreamFieldFile):
             return file
         if isinstance(file, File):


### PR DESCRIPTION
It seems single field field has a long standing bug. Not noticed since now one have used them until resently. Multi file fields works well.

Users can submit forms with single field fields but they can't be edited if they are empty.

This pr add a check for empire field fields and set the value to an empty list.