### PR TITLE
Fixup the behaviour with status

### DIFF
--- a/opentech/static_src/src/app/src/SubmissionsByRoundApp.js
+++ b/opentech/static_src/src/app/src/SubmissionsByRoundApp.js
@@ -31,9 +31,7 @@ class SubmissionsByRoundApp extends React.Component {
 
 const mapDispatchToProps = dispatch => {
     return {
-        setSubmissionRound: id => {
-            dispatch(setCurrentSubmissionRound(id));
-        },
+        setSubmissionRound: id => {dispatch(setCurrentSubmissionRound(id));},
     }
 };
 

--- a/opentech/static_src/src/app/src/SubmissionsByStatusApp.js
+++ b/opentech/static_src/src/app/src/SubmissionsByStatusApp.js
@@ -2,22 +2,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SwitcherApp from './SwitcherApp';
 import { hot } from 'react-hot-loader';
+import { connect } from 'react-redux'
 
 import GroupByRoundDetailView from '@containers/GroupByRoundDetailView';
+import { setCurrentStatuses } from '@actions/submissions';
 
 
 class SubmissionsByStatusApp extends React.Component {
     static propTypes = {
         pageContent: PropTypes.node.isRequired,
         statuses: PropTypes.arrayOf(PropTypes.string),
+        setStatuses: PropTypes.func.isRequired,
     };
+
+    componentDidMount() {
+        this.props.setStatuses(this.props.statuses);
+    }
 
     render() {
         return <SwitcherApp
-                detailComponent={<GroupByRoundDetailView submissionStatuses={this.props.statuses} />}
+                detailComponent={<GroupByRoundDetailView />}
                 switcherSelector={'submissions-by-status-app-react-switcher'}
                 pageContent={this.props.pageContent} />;
     }
 }
 
-export default hot(module)(SubmissionsByStatusApp);
+const mapDispatchToProps = dispatch => {
+    return {
+        setStatuses: statuses => {dispatch(setCurrentStatuses(statuses));},
+    }
+};
+
+
+export default hot(module)(
+    connect(null, mapDispatchToProps)(SubmissionsByStatusApp)
+);

--- a/opentech/static_src/src/app/src/containers/ByRoundListing.js
+++ b/opentech/static_src/src/app/src/containers/ByRoundListing.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import GroupedListing from '@components/GroupedListing';
 import {
     loadRounds,
-    loadSubmissionsOfStatuses,
+    loadSubmissionsForCurrentStatus,
     setCurrentSubmission,
 } from '@actions/submissions';
 import {
@@ -14,11 +14,14 @@ import {
     getRoundsErrored,
 } from '@selectors/rounds';
 import {
-    getSubmissionsByGivenStatuses,
     getCurrentSubmissionID,
-    getByGivenStatusesError,
-    getByGivenStatusesLoading,
+    getCurrentStatusesSubmissions,
 } from '@selectors/submissions';
+import {
+    getCurrentStatuses,
+    getByStatusesLoading,
+    getByStatusesError,
+} from '@selectors/statuses';
 
 
 const loadData = props => {
@@ -28,7 +31,7 @@ const loadData = props => {
 
 class ByRoundListing extends React.Component {
     static propTypes = {
-        submissionStatuses: PropTypes.arrayOf(PropTypes.string),
+        statuses: PropTypes.arrayOf(PropTypes.string),
         loadSubmissions: PropTypes.func,
         submissions: PropTypes.arrayOf(PropTypes.object),
         isErrored: PropTypes.bool,
@@ -41,15 +44,14 @@ class ByRoundListing extends React.Component {
     };
 
     componentDidMount() {
-        // Update items if round ID is defined.
-        if ( this.props.submissionStatuses ) {
+        if ( this.props.statuses) {
             loadData(this.props)
         }
     }
 
     componentDidUpdate(prevProps) {
-        const { submissionStatuses } = this.props;
-        if (!submissionStatuses.every(v => prevProps.submissionStatuses.includes(v))) {
+        const { statuses} = this.props;
+        if (!statuses.every(v => prevProps.statuses.includes(v))) {
             loadData(this.props)
         }
     }
@@ -85,20 +87,21 @@ class ByRoundListing extends React.Component {
     }
 }
 
-const mapStateToProps = (state, ownProps) => ({
-    submissions: getSubmissionsByGivenStatuses(ownProps.submissionStatuses)(state),
+const mapStateToProps = (state) => ({
+    statuses: getCurrentStatuses(state),
+    submissions: getCurrentStatusesSubmissions(state),
     isErrored: getRoundsErrored(state),
-    errorMessage: getByGivenStatusesError(ownProps.submissionStatuses)(state),
+    errorMessage: getByStatusesError(state),
     isLoading: (
-        getByGivenStatusesLoading(ownProps.submissionStatuses)(state) ||
+        getByStatusesLoading(state) ||
         getRoundsFetching(state)
     ),
     activeSubmission: getCurrentSubmissionID(state),
     rounds: getRounds(state),
 })
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-    loadSubmissions: () => dispatch(loadSubmissionsOfStatuses(ownProps.submissionStatuses)),
+const mapDispatchToProps = (dispatch) => ({
+    loadSubmissions: () => dispatch(loadSubmissionsForCurrentStatus()),
     loadRounds: () => dispatch(loadRounds()),
     setCurrentItem: id => dispatch(setCurrentSubmission(id)),
 });

--- a/opentech/static_src/src/app/src/containers/ByStatusListing.js
+++ b/opentech/static_src/src/app/src/containers/ByStatusListing.js
@@ -9,12 +9,14 @@ import {
     setCurrentSubmission,
 } from '@actions/submissions';
 import {
-    getCurrentRound,
-    getCurrentRoundID,
     getCurrentRoundSubmissions,
     getCurrentSubmissionID,
     getSubmissionsByRoundError,
 } from '@selectors/submissions';
+import {
+    getCurrentRound,
+    getCurrentRoundID,
+} from '@selectors/rounds';
 
 
 const loadData = props => {

--- a/opentech/static_src/src/app/src/containers/GroupByRoundDetailView.js
+++ b/opentech/static_src/src/app/src/containers/GroupByRoundDetailView.js
@@ -9,15 +9,17 @@ import {
     getRoundsErrored,
 } from '@selectors/rounds';
 import {
-    getByGivenStatusesLoading,
-    getByGivenStatusesError,
-    getCurrentRoundSubmissions,
+    getCurrentStatusesSubmissions,
     getCurrentSubmissionID,
 } from '@selectors/submissions';
+import {
+    getByStatusesLoading,
+    getByStatusesError,
+} from '@selectors/statuses';
+
 
 class GroupByRoundDetailView extends React.Component {
     static propTypes = {
-        submissionStatuses: PropTypes.arrayOf(PropTypes.string),
         submissions: PropTypes.arrayOf(PropTypes.object),
         submissionID: PropTypes.number,
         isLoading: PropTypes.bool,
@@ -26,7 +28,6 @@ class GroupByRoundDetailView extends React.Component {
     };
 
     render() {
-        const listing = <ByRoundListing submissionStatuses={this.props.submissionStatuses} />;
         const { isLoading, isErrored, submissions, submissionID, errorMessage } = this.props;
         const isEmpty = submissions.length === 0;
         const activeSubmision = !!submissionID;
@@ -34,7 +35,7 @@ class GroupByRoundDetailView extends React.Component {
         return (
             <DetailView
                 isEmpty={isEmpty}
-                listing={listing}
+                listing={<ByRoundListing />}
                 isLoading={isLoading}
                 showSubmision={activeSubmision}
                 isErrored={isErrored}
@@ -45,13 +46,11 @@ class GroupByRoundDetailView extends React.Component {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-    isErrored: getRoundsErrored(state),
-    errorMessage: getByGivenStatusesError(ownProps.submissionStatuses)(state),
+    isErrored: getRoundsErrored(state) || getByStatusesError(state),
     isLoading: (
-        getByGivenStatusesLoading(ownProps.submissionStatuses)(state) ||
-        getRoundsFetching(state)
+        getByStatusesLoading(state) || getRoundsFetching(state)
     ),
-    submissions: getCurrentRoundSubmissions(state),
+    submissions: getCurrentStatusesSubmissions(state),
     submissionID: getCurrentSubmissionID(state),
 })
 

--- a/opentech/static_src/src/app/src/containers/GroupByStatusDetailView.js
+++ b/opentech/static_src/src/app/src/containers/GroupByStatusDetailView.js
@@ -6,12 +6,14 @@ import DetailView from '@components/DetailView';
 import ByStatusListing from '@containers/ByStatusListing';
 
 import {
-    getCurrentRound,
     getSubmissionsByRoundError,
     getCurrentRoundSubmissions,
     getCurrentSubmissionID,
     getSubmissionErrorState,
 } from '@selectors/submissions';
+import {
+    getCurrentRound,
+} from '@selectors/rounds';
 
 
 class GroupByStatusDetailView extends React.Component {

--- a/opentech/static_src/src/app/src/redux/actions/submissions.js
+++ b/opentech/static_src/src/app/src/redux/actions/submissions.js
@@ -5,12 +5,20 @@ import api from '@api';
 import {
     getCurrentSubmission,
     getCurrentSubmissionID,
+    getCurrentStatusesSubmissions
+} from '@selectors/submissions';
+
+import {
+    getCurrentStatuses,
+    getSubmissionIDsForCurrentStatuses,
+} from '@selectors/statuses';
+
+import {
+    getRounds,
     getCurrentRoundID,
     getCurrentRound,
     getCurrentRoundSubmissionIDs,
-    getRounds,
-    getSubmissionsByGivenStatuses,
-} from '@selectors/submissions';
+} from '@selectors/rounds';
 
 
 // Round
@@ -31,9 +39,10 @@ export const START_LOADING_SUBMISSIONS_BY_ROUND = 'START_LOADING_SUBMISSIONS_BY_
 export const FAIL_LOADING_SUBMISSIONS_BY_ROUND = 'FAIL_LOADING_SUBMISSIONS_BY_ROUND';
 
 // Submissions by statuses
-export const UPDATE_SUBMISSIONS_BY_STATUSES = 'UPDATE_SUBMISSIONS_BY_STATUSES';
-export const START_LOADING_SUBMISSIONS_BY_STATUSES = 'START_LOADING_SUBMISSIONS_BY_STATUSES';
-export const FAIL_LOADING_SUBMISSIONS_BY_STATUSES = 'FAIL_LOADING_SUBMISSIONS_BY_STATUSES';
+export const SET_CURRENT_STATUSES = "SET_CURRENT_STATUSES_FOR_SUBMISSIONS";
+export const UPDATE_BY_STATUSES = 'UPDATE_SUBMISSIONS_BY_STATUSES';
+export const START_LOADING_BY_STATUSES = 'START_LOADING_SUBMISSIONS_BY_STATUSES';
+export const FAIL_LOADING_BY_STATUSES = 'FAIL_LOADING_SUBMISSIONS_BY_STATUSES';
 
 // Submissions
 export const SET_CURRENT_SUBMISSION = 'SET_CURRENT_SUBMISSION';
@@ -143,31 +152,39 @@ const fetchSubmissionsByRound = (roundID) => ({
 })
 
 
-const fetchSubmissionsByStatuses = statuses => {
+export const setCurrentStatuses = (statuses) => (dispatch) => {
     if(!Array.isArray(statuses)) {
         throw new Error("Statuses have to be an array of statuses");
     }
 
+    return dispatch({
+        type: SET_CURRENT_STATUSES,
+        statuses,
+    });
+};
+
+
+const fetchSubmissionsByStatuses = (statuses) => {
     return {
         [CALL_API]: {
-            types: [ START_LOADING_SUBMISSIONS_BY_STATUSES, UPDATE_SUBMISSIONS_BY_STATUSES, FAIL_LOADING_SUBMISSIONS_BY_STATUSES],
+            types: [ START_LOADING_BY_STATUSES, UPDATE_BY_STATUSES, FAIL_LOADING_BY_STATUSES],
             endpoint: api.fetchSubmissionsByStatuses(statuses),
         },
         statuses,
     };
 };
 
-export const loadSubmissionsOfStatuses = statuses => (dispatch, getState) => {
+export const loadSubmissionsForCurrentStatus = () => (dispatch, getState) => {
     const state = getState()
-    const submissions = getSubmissionsByGivenStatuses(statuses)(state)
+    const submissions = getCurrentStatusesSubmissions(state)
 
     if ( submissions && submissions.length !== 0 ) {
         return null
     }
 
-    return dispatch(fetchSubmissionsByStatuses(statuses)).then(() => {
+    return dispatch(fetchSubmissionsByStatuses(getCurrentStatuses(state))).then(() => {
         const state = getState()
-        const ids = getSubmissionsByGivenStatuses(statuses)(state)
+        const ids = getSubmissionIDsForCurrentStatuses(state)
         if (!ids.includes(getCurrentSubmissionID(state))) {
             return dispatch(setCurrentSubmission(null))
         }

--- a/opentech/static_src/src/app/src/redux/reducers/index.js
+++ b/opentech/static_src/src/app/src/redux/reducers/index.js
@@ -4,10 +4,12 @@ import { connectRouter } from 'connected-react-router'
 import submissions from '@reducers/submissions';
 import rounds from '@reducers/rounds';
 import notes from '@reducers/notes';
+import statuses from '@reducers/statuses';
 
 export default combineReducers({
     router: connectRouter(history),
     notes,
-    submissions,
     rounds,
+    statuses,
+    submissions,
 });

--- a/opentech/static_src/src/app/src/redux/reducers/statuses.js
+++ b/opentech/static_src/src/app/src/redux/reducers/statuses.js
@@ -1,0 +1,67 @@
+import { combineReducers } from 'redux';
+
+import {
+    SET_CURRENT_STATUSES,
+    UPDATE_BY_STATUSES,
+    START_LOADING_BY_STATUSES,
+    FAIL_LOADING_BY_STATUSES,
+} from '@actions/submissions';
+
+
+function current(state = [], action) {
+    switch (action.type) {
+        case SET_CURRENT_STATUSES:
+            return [...action.statuses]
+        default:
+            return state
+    }
+}
+
+function submissionsByStatuses(state = {}, action) {
+    switch (action.type) {
+        case UPDATE_BY_STATUSES:
+            return {
+                ...state,
+                ...action.data.results.reduce((accumulator, submission) => {
+                    const submissions = accumulator[submission.status] || []
+                    if ( !submissions.includes(submission.id) ) {
+                        accumulator[submission.status] = [...submissions, submission.id]
+                    }
+                    return accumulator
+                }, state)
+            };
+        default:
+            return state
+    }
+}
+
+
+function statusFetchingState(state = {isFetching: true, isError: false}, action) {
+    switch (action.type) {
+        case FAIL_LOADING_BY_STATUSES:
+            return {
+                isFetching: false,
+                isErrored: true,
+            };
+        case START_LOADING_BY_STATUSES:
+            return {
+                isFetching: true,
+                isErrored: false,
+            };
+        case UPDATE_BY_STATUSES:
+            return {
+                isFetching: false,
+                isErrored: false,
+            };
+        default:
+            return state
+    }
+}
+
+const statuses = combineReducers({
+    current,
+    byStatuses: submissionsByStatuses,
+    fetchingState: statusFetchingState,
+});
+
+export default statuses;

--- a/opentech/static_src/src/app/src/redux/reducers/submissions.js
+++ b/opentech/static_src/src/app/src/redux/reducers/submissions.js
@@ -7,9 +7,7 @@ import {
     UPDATE_SUBMISSIONS_BY_ROUND,
     UPDATE_SUBMISSION,
     SET_CURRENT_SUBMISSION,
-    UPDATE_SUBMISSIONS_BY_STATUSES,
-    START_LOADING_SUBMISSIONS_BY_STATUSES,
-    FAIL_LOADING_SUBMISSIONS_BY_STATUSES,
+    UPDATE_BY_STATUSES,
 } from '@actions/submissions';
 
 import { UPDATE_NOTES, UPDATE_NOTE } from '@actions/notes'
@@ -69,7 +67,7 @@ function submissionsByID(state = {}, action) {
                 ...state,
                 [action.submissionID]: submission(state[action.submissionID], action),
             };
-        case UPDATE_SUBMISSIONS_BY_STATUSES:
+        case UPDATE_BY_STATUSES:
         case UPDATE_SUBMISSIONS_BY_ROUND:
             return {
                 ...state,
@@ -102,52 +100,9 @@ function currentSubmission(state = null, action) {
 }
 
 
-function submissionsByStatuses(state = {}, action) {
-    switch (action.type) {
-        case UPDATE_SUBMISSIONS_BY_STATUSES:
-            return {
-                ...state,
-                ...action.data.results.reduce((accumulator, submission) => {
-                    const submissions = accumulator[submission.status] || []
-                    if ( !submissions.includes(submission.id) ) {
-                        accumulator[submission.status] = [...submissions, submission.id]
-                    }
-                    return state
-                }, state)
-            };
-        default:
-            return state
-    }
-}
-
-
-function submissionsFetchingState(state = {isFetching: true, isError: false}, action) {
-    switch (action.type) {
-        case FAIL_LOADING_SUBMISSIONS_BY_STATUSES:
-            return {
-                isFetching: false,
-                isErrored: true,
-            };
-        case START_LOADING_SUBMISSIONS_BY_STATUSES:
-            return {
-                isFetching: true,
-                isErrored: false,
-            };
-        case UPDATE_SUBMISSIONS_BY_STATUSES:
-            return {
-                isFetching: true,
-                isErrored: false,
-            };
-        default:
-            return state
-    }
-}
-
 const submissions = combineReducers({
     byID: submissionsByID,
     current: currentSubmission,
-    byStatuses: submissionsByStatuses,
-    fetchingState: submissionsFetchingState,
 });
 
 export default submissions;

--- a/opentech/static_src/src/app/src/redux/selectors/statuses.js
+++ b/opentech/static_src/src/app/src/redux/selectors/statuses.js
@@ -1,0 +1,33 @@
+import { createSelector } from 'reselect';
+
+
+const getCurrentStatuses = state => state.statuses.current;
+
+const getStatusesFetchingState = state => state.statuses.fetchingState;
+
+const getSubmissionsByStatuses = state => state.statuses.byStatuses;
+
+
+const getSubmissionIDsForCurrentStatuses = createSelector(
+    [ getSubmissionsByStatuses, getCurrentStatuses ],
+    (grouped, current) => {
+        return current.reduce((acc, status) => acc.concat(grouped[status] || []), [])
+    }
+);
+
+const getByStatusesError = createSelector(
+    [ getStatusesFetchingState ],
+    state => state.isErrored === true
+);
+
+const getByStatusesLoading = createSelector(
+    [ getStatusesFetchingState ],
+    state => state.isFetching === true
+);
+
+export {
+    getCurrentStatuses,
+    getByStatusesLoading,
+    getByStatusesError,
+    getSubmissionIDsForCurrentStatuses,
+}

--- a/opentech/static_src/src/app/src/redux/selectors/submissions.js
+++ b/opentech/static_src/src/app/src/redux/selectors/submissions.js
@@ -1,43 +1,28 @@
 import { createSelector } from 'reselect';
 
 import {
-    getCurrentRound,
-    getCurrentRoundID,
     getCurrentRoundSubmissionIDs,
-    getRounds,
 } from '@selectors/rounds';
+
+import {
+    getSubmissionIDsForCurrentStatuses,
+} from '@selectors/statuses';
 
 const getSubmissions = state => state.submissions.byID;
 
-const getSubmissionsByStatuses = state => state.submissions.byStatuses;
-
-const getSubmissionsFetchingState = state => state.submissions.fetchingState;
-
 const getCurrentSubmissionID = state => state.submissions.current;
 
-const getByGivenStatusesObject = statuses => createSelector(
-    [getSubmissionsByStatuses], (byStatuses) => {
-        return statuses.reduce((acc, status) => acc.concat(byStatuses[status] || []), [])
-    }
-);
-
-const getSubmissionsByGivenStatuses = statuses => createSelector(
-    [getSubmissions, getByGivenStatusesObject(statuses)],
-    (submissions, byStatus) => byStatus.map(id => submissions[id])
-);
-
-const getByGivenStatusesError = statuses => createSelector(
-    [getSubmissionsFetchingState],
-    state => state.isErrored === true
-);
-
-const getByGivenStatusesLoading = statuses => createSelector(
-    [getByGivenStatusesObject],
-    state => state.isFetching === true
-);
 
 const getCurrentRoundSubmissions = createSelector(
     [ getCurrentRoundSubmissionIDs, getSubmissions],
+    (submissionIDs, submissions) => {
+        return submissionIDs.map(submissionID => submissions[submissionID]);
+    }
+);
+
+
+const getCurrentStatusesSubmissions = createSelector(
+    [ getSubmissionIDsForCurrentStatuses, getSubmissions],
     (submissionIDs, submissions) => {
         return submissionIDs.map(submissionID => submissions[submissionID]);
     }
@@ -64,19 +49,13 @@ const getSubmissionsByRoundError = state => state.rounds.error;
 const getSubmissionsByRoundLoadingState = state => state.submissions.itemsLoading === true;
 
 export {
-    getByGivenStatusesError,
-    getByGivenStatusesLoading,
-    getCurrentRoundID,
-    getCurrentRound,
-    getCurrentRoundSubmissionIDs,
     getCurrentRoundSubmissions,
     getCurrentSubmission,
     getCurrentSubmissionID,
-    getRounds,
     getSubmissionsByRoundError,
     getSubmissionsByRoundLoadingState,
     getSubmissionLoadingState,
     getSubmissionErrorState,
     getSubmissionOfID,
-    getSubmissionsByGivenStatuses,
+    getCurrentStatusesSubmissions,
 };


### PR DESCRIPTION
@tm-kn this makes the statuses be more like the round - we set a current set of statuses and then refer to that elsewhere.

It removes the passing around of the statuses within the components.

I've also split out the selectors into multiple files to be more explicit and reduce confusion. 