### PR TITLE
CI test failure fix (testing to see if this fixes the issue)

### DIFF
--- a/opentech/apply/funds/tests/test_views.py
+++ b/opentech/apply/funds/tests/test_views.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import json
 
 from django.test import TestCase
+from django.utils.text import slugify
 
 from opentech.apply.activity.models import Activity, INTERNAL
 from opentech.apply.determinations.tests.factories import DeterminationFactory
@@ -215,7 +216,7 @@ class TestReviewersUpdateView(BaseSubmissionViewTestCase):
         }
         data.update(
             **{
-                f'role_reviewer_{str(role)}': reviewer.id
+                f'role_reviewer_{slugify(str(role))}': reviewer.id
                 for role, reviewer in zip(self.roles, reviewer_roles)
             }
         )


### PR DESCRIPTION
I was thinking that maybe faker was creating words for role names that weren't playing well with the form field names, so I added slugify to see if it fixed the test that are sometimes failing on these tests. These tests all use the `reviewer_roles` field when they post the form, so I'm thinking that might have been the issue. No other tests use that field, and these are the 3 tests that keep occasionally failing.