### PR TITLE
Feature/961 disagree behaviour

### DIFF
--- a/opentech/apply/review/tests/test_views.py
+++ b/opentech/apply/review/tests/test_views.py
@@ -7,7 +7,7 @@ from opentech.apply.utils.testing.tests import BaseViewTestCase
 
 from .factories import ReviewFactory, ReviewFormFieldsFactory, ReviewFormFactory, ReviewOpinionFactory
 from ..models import Review, ReviewOpinion
-from ..options import NA, AGREE
+from ..options import NA, AGREE, DISAGREE
 
 
 class StaffReviewsTestCase(BaseViewTestCase):
@@ -267,6 +267,13 @@ class StaffReviewOpinionCase(BaseViewTestCase):
         self.assertTrue(review.opinions.first().opinion_display in Activity.objects.first().message)
         self.assertEqual(ReviewOpinion.objects.all().count(), 1)
         self.assertEqual(ReviewOpinion.objects.first().opinion, AGREE)
+
+    def test_disagree_opinion_redirects_to_review_form(self):
+        staff = StaffFactory()
+        review = ReviewFactory(submission=self.submission, author=staff, recommendation_yes=True)
+        response = self.post_page(review, {'agree': DISAGREE})
+        url = self.url_from_pattern('funds:submissions:reviews:form', kwargs={'submission_pk': self.submission.id})
+        self.assertRedirects(response, url)
 
 
 class NonStaffReviewOpinionCase(BaseViewTestCase):

--- a/opentech/apply/review/tests/test_views.py
+++ b/opentech/apply/review/tests/test_views.py
@@ -273,7 +273,7 @@ class StaffReviewOpinionCase(BaseViewTestCase):
     def test_disagree_opinion_redirects_to_review_form(self):
         staff = StaffFactory()
         review = ReviewFactory(submission=self.submission, author=staff, recommendation_yes=True)
-        response = self.post_page(review, {'agree': DISAGREE})
+        response = self.post_page(review, {'disagree': DISAGREE})
         url = self.url_from_pattern('funds:submissions:reviews:form', kwargs={'submission_pk': self.submission.id})
         self.assertRedirects(response, url)
 

--- a/opentech/apply/review/tests/test_views.py
+++ b/opentech/apply/review/tests/test_views.py
@@ -263,10 +263,12 @@ class StaffReviewOpinionCase(BaseViewTestCase):
     def test_can_add_opinion_to_others_review(self):
         staff = StaffFactory()
         review = ReviewFactory(submission=self.submission, author=staff, recommendation_yes=True)
-        self.post_page(review, {'agree': AGREE})
-        self.assertTrue(review.opinions.first().opinion_display in Activity.objects.first().message)
+        response = self.post_page(review, {'agree': AGREE})
+        self.assertTrue('agrees' in Activity.objects.first().message)
         self.assertEqual(ReviewOpinion.objects.all().count(), 1)
         self.assertEqual(ReviewOpinion.objects.first().opinion, AGREE)
+        url = self.url_from_pattern('apply:submissions:reviews:review', kwargs={'submission_pk': self.submission.pk, 'pk': review.id})
+        self.assertRedirects(response, url)
 
     def test_disagree_opinion_redirects_to_review_form(self):
         staff = StaffFactory()

--- a/opentech/apply/review/tests/test_views.py
+++ b/opentech/apply/review/tests/test_views.py
@@ -264,7 +264,7 @@ class StaffReviewOpinionCase(BaseViewTestCase):
         staff = StaffFactory()
         review = ReviewFactory(submission=self.submission, author=staff, recommendation_yes=True)
         response = self.post_page(review, {'agree': AGREE})
-        self.assertTrue('agrees' in Activity.objects.first().message)
+        self.assertTrue(review.opinions.first().opinion_display in Activity.objects.first().message)
         self.assertEqual(ReviewOpinion.objects.all().count(), 1)
         self.assertEqual(ReviewOpinion.objects.first().opinion, AGREE)
         url = self.url_from_pattern('apply:submissions:reviews:review', kwargs={'submission_pk': self.submission.pk, 'pk': review.id})

--- a/opentech/apply/review/views.py
+++ b/opentech/apply/review/views.py
@@ -202,7 +202,7 @@ class ReviewOpinionFormView(CreateView):
             related=opinion,
         )
 
-        if opinion == DISAGREE:
+        if opinion.opinion == DISAGREE:
             return HttpResponseRedirect(reverse('apply:submissions:reviews:form', args=(self.review.submission.pk,)))
         else:
             return response

--- a/opentech/apply/review/views.py
+++ b/opentech/apply/review/views.py
@@ -21,6 +21,7 @@ from opentech.apply.users.models import User
 from opentech.apply.utils.views import CreateOrUpdateView
 
 from .models import Review
+from .options import DISAGREE
 
 
 class ReviewContextMixin:
@@ -191,15 +192,20 @@ class ReviewOpinionFormView(CreateView):
         form.instance.author = self.request.user
         form.instance.review = self.review
         response = super().form_valid(form)
+        opinion = form.instance
 
         messenger(
             MESSAGES.REVIEW_OPINION,
             request=self.request,
             user=self.request.user,
             submission=self.review.submission,
-            related=form.instance,
+            related=opinion,
         )
-        return response
+
+        if opinion == DISAGREE:
+            return HttpResponseRedirect(reverse('apply:submissions:reviews:form', args=(self.review.submission.pk,)))
+        else:
+            return response
 
     def get_success_url(self):
         return self.review.get_absolute_url()

--- a/opentech/apply/review/views.py
+++ b/opentech/apply/review/views.py
@@ -203,7 +203,7 @@ class ReviewOpinionFormView(CreateView):
         )
 
         if opinion.opinion == DISAGREE:
-            return HttpResponseRedirect(reverse('apply:submissions:reviews:form', args=(self.review.submission.pk,)))
+            return HttpResponseRedirect(reverse_lazy('apply:submissions:reviews:form', args=(self.review.submission.pk,)))
         else:
             return response
 


### PR DESCRIPTION
https://github.com/opentechfund/opentech.fund/issues/961

* On clicking the Disagree button your opinion will be recorded and you will be redirected to complete a new review
* Test for this redirect on disagree
* Added a line to the test on agree that checks that it redirects correctly as well

This has been branched off of 962 (pull request  for 962: https://github.com/OpenTechFund/opentech.fund/pull/1034)