### PR TITLE
Add checks that person_type and news_type queries are numerical and i…

### DIFF
--- a/opentech/public/news/models.py
+++ b/opentech/public/news/models.py
@@ -142,7 +142,7 @@ class NewsIndex(BasePage):
             'authors__author',
         )
 
-        if request.GET.get('news_type'):
+        if request.GET.get('news_type') and request.GET.get('news_type').isdigit():
             news = news.filter(news_types__news_type=request.GET.get('news_type'))
 
         # Pagination

--- a/opentech/public/people/models.py
+++ b/opentech/public/people/models.py
@@ -218,7 +218,7 @@ class PersonIndexPage(BasePage):
             'person_types__person_type',
         )
 
-        if request.GET.get('person_type'):
+        if request.GET.get('person_type') and request.GET.get('person_type').isdigit():
             people = people.filter(person_types__person_type=request.GET.get('person_type'))
 
         if not request.GET.get('include_inactive') == 'true':

--- a/opentech/public/search/views.py
+++ b/opentech/public/search/views.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import Http404
@@ -17,6 +19,10 @@ def search(request):
 
     # Search
     if search_query:
+        # Allow only word characters and spaces in search query.
+        words = re.findall('\w+', search_query.strip())
+        search_query = ' '.join(words)
+
         public_site = request.site.root_page
 
         search_results = Page.objects.live().descendant_of(


### PR DESCRIPTION
…gnore otherwise. Avoids a lot of invalid literal for int errors.

See "ValueError" in Sentry.