### PR TITLE
Improve perf by not firing db query when review author and review opinion author is accessed

### DIFF
--- a/opentech/apply/review/models.py
+++ b/opentech/apply/review/models.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.core.fields import StreamField
 
-from opentech.apply.funds.models import AssignedReviewers
 from opentech.apply.funds.models.mixins import AccessFormData
 from opentech.apply.review.options import YES, NO, MAYBE, RECOMMENDATION_CHOICES, OPINION_CHOICES
 from opentech.apply.stream_forms.models import BaseStreamForm
@@ -167,6 +166,7 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
 
 @receiver(post_save, sender=Review)
 def update_submission_reviewers_list(sender, **kwargs):
+    from opentech.apply.funds.models import AssignedReviewers
     review = kwargs.get('instance')
 
     # Make sure the reviewer is in the reviewers list on the submission


### PR DESCRIPTION
Link #1081 

Currently, a query is fired for each row in the submissions list table when [review author](https://github.com/OpenTechFund/opentech.fund/blob/2c8c3de93b4b9581a6aaaf99867d8cb0f9ad5f2b/opentech/apply/funds/templates/funds/tables/table.html#L43) and review [opinion author](https://github.com/OpenTechFund/opentech.fund/blob/2c8c3de93b4b9581a6aaaf99867d8cb0f9ad5f2b/opentech/apply/funds/templates/funds/tables/table.html#L52) is accessed in the template. Uses [Prefetch](https://docs.djangoproject.com/en/2.1/ref/models/querysets/#prefetch-objects) objects.

Also, are we using Opinion on the Review feature in the apply site? The code is present but not sure it is being used. If not we can update the modified code.