### PR TITLE
Set correct Cache-Control max-age and s-maxage headers on all pages

### DIFF
--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -212,11 +212,16 @@ else:
         }
     }
 
+# Set max-age header. See urls.py
+try:
+    CACHE_CONTROL_MAX_AGE = int(env.get('CACHE_CONTROL_MAX_AGE', 0))
+except ValueError:
+    pass
 
 # Set s-max-age header that is used by reverse proxy/front end cache. See
 # urls.py
 try:
-    CACHE_CONTROL_S_MAXAGE = int(env.get('CACHE_CONTROL_S_MAXAGE', 600))
+    CACHE_CONTROL_S_MAXAGE = int(env.get('CACHE_CONTROL_S_MAXAGE', 0))
 except ValueError:
     pass
 

--- a/opentech/urls.py
+++ b/opentech/urls.py
@@ -19,11 +19,24 @@ from opentech.apply.users.urls import public_urlpatterns as user_urls
 def apply_cache_control(*patterns):
     # Cache-control
     cache_length = getattr(settings, 'CACHE_CONTROL_MAX_AGE', None)
+    cache_s_length = getattr(settings, 'CACHE_CONTROL_S_MAXAGE', None)
 
-    if cache_length:
+    if cache_length and not cache_s_length:
         patterns = decorate_urlpatterns(
             patterns,
             cache_control(max_age=cache_length)
+        )
+
+    if not cache_length and cache_s_length:
+        patterns = decorate_urlpatterns(
+            patterns,
+            cache_control(s_maxage=cache_s_length)
+        )
+
+    if cache_length and cache_s_length:
+        patterns = decorate_urlpatterns(
+            patterns,
+            cache_control(max_age=cache_length, s_maxage=cache_s_length)
         )
 
     return list(patterns)


### PR DESCRIPTION
I have added one commit to allow CACHE_CONTROL_MAX_AGE and CACHE_CONTROL_S_MAXAGE environment variables to be set, they default to 0.

CACHE_CONTROL_MAX_AGE => max-age
CACHE_CONTROL_S_MAXAGE => s-maxage (Cloudflare will use this if present, otherwise standard max-age)

* Set never cache on all pages on the Apply site except the front page. They seem to have no cache_control header at all currently. 