### PR TITLE
put people who don't have an order set after those who do

### DIFF
--- a/opentech/static_src/src/app/src/containers/ReviewInformation.js
+++ b/opentech/static_src/src/app/src/containers/ReviewInformation.js
@@ -34,6 +34,8 @@ const ReviewInformation = ({ submission }) => {
         people.sort((a,b) => {
             if (a.role.order === null) {
                 return 100;
+            } else if (b.role.order === null) {
+                return -1;
             }
             return a.role.order - b.role.order;
         })


### PR DESCRIPTION
This was occurring because an `order` hadn't been set in the backend under Apply > Reviewer Roles > Secondary so the order value was `null`. Anyone with this value is now moved after those who have a value. Suggest we also make this field mandatory in the backend.