### PR TITLE
Do not display workflow when a round is created to avoid confusion of default value

### DIFF
--- a/opentech/apply/funds/edit_handlers.py
+++ b/opentech/apply/funds/edit_handlers.py
@@ -65,7 +65,12 @@ class ReadOnlyPanel(EditHandler):
         if callable(value):
             value = value()
 
-        self.form.initial[self.attr] = value
+        # Add initial value only when an object is present. Display nothing when a new page is being
+        # created. As it is a read-only panel and creates confusion when default values are displayed.
+        if self.instance.id:
+            self.form.initial[self.attr] = value
+        else:
+            self.form.initial[self.attr] = '-'
         self.bound_field = DisplayField().get_bound_field(self.form, self.attr)
         return {
             'self': self,

--- a/opentech/apply/funds/models/applications.py
+++ b/opentech/apply/funds/models/applications.py
@@ -167,7 +167,7 @@ class RoundBase(WorkflowStreamForm, SubmittableStreamForm):  # type: ignore
             ]),
         ], heading="Dates"),
         FieldPanel('reviewers'),
-        ReadOnlyPanel('get_workflow_name_display', heading="Workflow"),
+        ReadOnlyPanel('get_workflow_name_display', heading="Workflow", help_text="Copied from the fund."),
         # Forms comes from parental key in models/forms.py
         ReadOnlyInlinePanel('forms', help_text="Copied from the fund."),
         ReadOnlyInlinePanel('review_forms', help_text="Copied from the fund."),


### PR DESCRIPTION
Closes #1069 

Currently, we display default value for a read-only field like workflow while creating a round page. The workflow default value is [single](https://github.com/OpenTechFund/opentech.fund/blob/322c41732872b9dc1e208273ff970fdcdb8066de/opentech/apply/funds/models/utils.py#L43) therefore [request](https://github.com/OpenTechFund/opentech.fund/blob/322c41732872b9dc1e208273ff970fdcdb8066de/opentech/apply/funds/workflow.py#L824) is displayed in the workflow field which creates confusion. It seems better to display nothing for workflow name like forms, review forms when a new round is being created. After a round is created, values are displayed which are copied from the parent Fund page.