### PR TITLE
Submission private media shareable URL with permissions checks

### DIFF
--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -54,14 +54,14 @@ class AccessFormData:
         if isinstance(file, StreamFieldFile):
             return file
         if isinstance(file, File):
-            return StreamFieldFile(file, name=file.name, storage=submission_storage)
+            return StreamFieldFile(file, name=file.name, storage=submission_storage, is_submission=True)
 
         # This fixes a backwards compatibility issue with #507
         # Once every application has been re-saved it should be possible to remove it
         if 'path' in file:
             file['filename'] = file['name']
             file['name'] = file['path']
-        return StreamFieldFile(None, name=file['name'], filename=file.get('filename'), storage=submission_storage)
+        return StreamFieldFile(None, name=file['name'], filename=file.get('filename'), storage=submission_storage, is_submission=True)
 
     @classmethod
     def process_file(cls, file):

--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -15,7 +15,13 @@ from opentech.apply.stream_forms.files import StreamFieldFile
 __all__ = ['AccessFormData']
 
 
-submission_storage = get_storage_class(getattr(settings, 'PRIVATE_FILE_STORAGE', None))()
+private_file_storage = getattr(settings, 'PRIVATE_FILE_STORAGE', None)
+submission_storage_class = get_storage_class(private_file_storage)
+
+if private_file_storage:
+    submission_storage = submission_storage_class(is_submission=True)
+else:
+    submission_storage = submission_storage_class()
 
 
 class UnusedFieldException(Exception):

--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -54,14 +54,14 @@ class AccessFormData:
         if isinstance(file, StreamFieldFile):
             return file
         if isinstance(file, File):
-            return StreamFieldFile(file, name=file.name, storage=submission_storage, is_submission=True)
+            return StreamFieldFile(file, name=file.name, storage=submission_storage)
 
         # This fixes a backwards compatibility issue with #507
         # Once every application has been re-saved it should be possible to remove it
         if 'path' in file:
             file['filename'] = file['name']
             file['name'] = file['path']
-        return StreamFieldFile(None, name=file['name'], filename=file.get('filename'), storage=submission_storage, is_submission=True)
+        return StreamFieldFile(None, name=file['name'], filename=file.get('filename'), storage=submission_storage)
 
     @classmethod
     def process_file(cls, file):

--- a/opentech/apply/funds/permissions.py
+++ b/opentech/apply/funds/permissions.py
@@ -16,3 +16,21 @@ class IsApplyStaffUser(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return request.user.is_apply_staff
+
+
+def is_user_has_access_to_view_submission(user, submission):
+    has_access = False
+
+    if not user.is_authenticated:
+        pass
+
+    elif user.is_apply_staff or submission.user == user or user.is_reviewer:
+        has_access = True
+
+    elif user.is_partner and submission.partners.filter(pk=user.pk).exists():
+        has_access = True
+
+    elif user.is_community_reviewer and submission.community_review:
+        has_access = True
+
+    return has_access

--- a/opentech/apply/funds/urls.py
+++ b/opentech/apply/funds/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, path, re_path
 
 from .views import (
     RevisionCompareView,
@@ -12,6 +12,7 @@ from .views import (
     SubmissionOverviewView,
     SubmissionSealedView,
     SubmissionDeleteView,
+    SubmissionPrivateMediaRedirectView,
 )
 from .api_views import (
     CommentEdit,
@@ -36,6 +37,7 @@ app_name = 'funds'
 submission_urls = ([
     path('', SubmissionOverviewView.as_view(), name="overview"),
     path('all/', SubmissionListView.as_view(), name="list"),
+    re_path('documents/(.*)$', SubmissionPrivateMediaRedirectView.as_view(), name='private_media_redirect'),
     path('<int:pk>/', include([
         path('', SubmissionDetailView.as_view(), name="detail"),
         path('edit/', SubmissionEditView.as_view(), name="edit"),

--- a/opentech/apply/funds/urls.py
+++ b/opentech/apply/funds/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path, re_path
+from django.urls import include, path
 
 from .views import (
     RevisionCompareView,
@@ -37,7 +37,10 @@ app_name = 'funds'
 submission_urls = ([
     path('', SubmissionOverviewView.as_view(), name="overview"),
     path('all/', SubmissionListView.as_view(), name="list"),
-    re_path('documents/(.*)$', SubmissionPrivateMediaRedirectView.as_view(), name='private_media_redirect'),
+    path(
+        'documents/submission/<int:submission_id>/<uuid:field_id>/<str:file_name>/',
+        SubmissionPrivateMediaRedirectView.as_view(), name='private_media_redirect'
+    ),
     path('<int:pk>/', include([
         path('', SubmissionDetailView.as_view(), name="detail"),
         path('edit/', SubmissionEditView.as_view(), name="edit"),

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -62,7 +62,7 @@ from .tables import (
 from .workflow import STAGE_CHANGE_ACTIONS, PHASES_MAPPING, review_statuses
 from .permissions import is_user_has_access_to_view_submission
 
-submission_storage = get_storage_class(getattr(settings, 'PRIVATE_FILE_STORAGE', None))
+submission_storage = get_storage_class(getattr(settings, 'PRIVATE_FILE_STORAGE', None))()
 
 
 class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -829,7 +829,7 @@ class SubmissionPrivateMediaRedirectView(UserPassesTestMixin, RedirectView):
         file_name = kwargs['file_name']
         file_name_with_path = f'submission/{submission_id}/{field_id}/{file_name}'
 
-        return submission_storage.url(file_name_with_path)
+        return submission_storage.url(file_name_with_path, proxy_url=False)
 
     def test_func(self):
         submission_id = self.kwargs['submission_id']

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -62,7 +62,13 @@ from .tables import (
 from .workflow import STAGE_CHANGE_ACTIONS, PHASES_MAPPING, review_statuses
 from .permissions import is_user_has_access_to_view_submission
 
-submission_storage = get_storage_class(getattr(settings, 'PRIVATE_FILE_STORAGE', None))()
+private_file_storage = getattr(settings, 'PRIVATE_FILE_STORAGE', None)
+submission_storage_class = get_storage_class(private_file_storage)
+
+if private_file_storage:
+    submission_storage = submission_storage_class(internal_url=False)
+else:
+    submission_storage = submission_storage_class()
 
 
 class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
@@ -829,7 +835,7 @@ class SubmissionPrivateMediaRedirectView(UserPassesTestMixin, RedirectView):
         file_name = kwargs['file_name']
         file_name_with_path = f'submission/{submission_id}/{field_id}/{file_name}'
 
-        return submission_storage.url(file_name_with_path, proxy_url=False)
+        return submission_storage.url(file_name_with_path)
 
     def test_func(self):
         submission_id = self.kwargs['submission_id']

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -62,13 +62,7 @@ from .tables import (
 from .workflow import STAGE_CHANGE_ACTIONS, PHASES_MAPPING, review_statuses
 from .permissions import is_user_has_access_to_view_submission
 
-private_file_storage = getattr(settings, 'PRIVATE_FILE_STORAGE', None)
-submission_storage_class = get_storage_class(private_file_storage)
-
-if private_file_storage:
-    submission_storage = submission_storage_class(internal_url=False)
-else:
-    submission_storage = submission_storage_class()
+submission_storage = get_storage_class(getattr(settings, 'PRIVATE_FILE_STORAGE', None))
 
 
 class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -59,6 +59,8 @@ from .tables import (
 )
 from .workflow import STAGE_CHANGE_ACTIONS, PHASES_MAPPING, review_statuses
 
+submission_storage = get_storage_class(getattr(settings, 'PRIVATE_FILE_STORAGE', None))()
+
 
 class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
     table_class = AdminSubmissionsTable
@@ -833,5 +835,4 @@ class SubmissionPrivateMediaRedirectView(RedirectView):
         # If user can access submission detail view then show the media
         can_access_detail_view = SubmissionDetailView.as_view()(self.request, pk=submission_id)
 
-        submission_storage = get_storage_class(getattr(settings, 'PRIVATE_FILE_STORAGE', None))()
         return submission_storage.url(file_name) if can_access_detail_view.status_code == 200 else None

--- a/opentech/apply/stream_forms/files.py
+++ b/opentech/apply/stream_forms/files.py
@@ -1,6 +1,5 @@
 import os
 
-from django.urls import reverse
 from django.core.files.base import File
 from django.core.files.storage import default_storage
 from django.core.serializers.json import DjangoJSONEncoder
@@ -17,12 +16,11 @@ class StreamFieldDataEncoder(DjangoJSONEncoder):
 
 
 class StreamFieldFile(File):
-    def __init__(self, *args, filename=None, storage=default_storage, is_submission=False, **kwargs):
+    def __init__(self, *args, filename=None, storage=default_storage, **kwargs):
         super().__init__(*args, **kwargs)
         self.storage = storage
         self.filename = filename or os.path.basename(self.name)
         self._committed = False
-        self.is_submission = is_submission
 
     def __str__(self):
         return self.filename
@@ -60,14 +58,6 @@ class StreamFieldFile(File):
 
     @property
     def url(self):
-        if self.is_submission:
-            name_parts = self.name.split('/')
-            return reverse(
-                'apply:submissions:private_media_redirect', kwargs={
-                    'submission_id': name_parts[1], 'field_id': name_parts[2],
-                    'file_name': name_parts[3]
-                }
-            )
         return self.storage.url(self.name)
 
     @property

--- a/opentech/apply/stream_forms/files.py
+++ b/opentech/apply/stream_forms/files.py
@@ -61,7 +61,13 @@ class StreamFieldFile(File):
     @property
     def url(self):
         if self.is_submission:
-            return reverse('apply:submissions:private_media_redirect', args=[self.name])
+            name_parts = self.name.split('/')
+            return reverse(
+                'apply:submissions:private_media_redirect', kwargs={
+                    'submission_id': name_parts[1], 'field_id': name_parts[2],
+                    'file_name': name_parts[3]
+                }
+            )
         return self.storage.url(self.name)
 
     @property

--- a/opentech/apply/stream_forms/files.py
+++ b/opentech/apply/stream_forms/files.py
@@ -1,5 +1,6 @@
 import os
 
+from django.urls import reverse
 from django.core.files.base import File
 from django.core.files.storage import default_storage
 from django.core.serializers.json import DjangoJSONEncoder
@@ -16,11 +17,12 @@ class StreamFieldDataEncoder(DjangoJSONEncoder):
 
 
 class StreamFieldFile(File):
-    def __init__(self, *args, filename=None, storage=default_storage, **kwargs):
+    def __init__(self, *args, filename=None, storage=default_storage, is_submission=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.storage = storage
         self.filename = filename or os.path.basename(self.name)
         self._committed = False
+        self.is_submission = is_submission
 
     def __str__(self):
         return self.filename
@@ -58,6 +60,8 @@ class StreamFieldFile(File):
 
     @property
     def url(self):
+        if self.is_submission:
+            return reverse('apply:submissions:private_media_redirect', args=[self.name])
         return self.storage.url(self.name)
 
     @property

--- a/opentech/storage_backends.py
+++ b/opentech/storage_backends.py
@@ -1,6 +1,7 @@
 from urllib import parse
 
 from django.conf import settings
+from django.urls import reverse
 from django.utils.encoding import filepath_to_uri
 from storages.backends.s3boto3 import S3Boto3Storage
 
@@ -29,7 +30,21 @@ class PrivateMediaStorage(S3Boto3Storage):
     querystring_auth = True
     url_protocol = 'https:'
 
-    def url(self, name, parameters=None, expire=None):
+    def url(self, name, parameters=None, expire=None, proxy_url=True):
+        if proxy_url:
+            try:
+                name_parts = name.split('/')
+                # Create and return Proxy URL only for submissions
+                if name_parts[0] == 'submission':
+                    return reverse(
+                        'apply:submissions:private_media_redirect', kwargs={
+                            'submission_id': name_parts[1], 'field_id': name_parts[2],
+                            'file_name': name_parts[3]
+                        }
+                    )
+            except IndexError:
+                pass
+
         url = super().url(name, parameters, expire)
 
         if hasattr(settings, 'AWS_PRIVATE_CUSTOM_DOMAIN'):

--- a/opentech/storage_backends.py
+++ b/opentech/storage_backends.py
@@ -29,20 +29,18 @@ class PrivateMediaStorage(S3Boto3Storage):
     file_overwrite = False
     querystring_auth = True
     url_protocol = 'https:'
-    internal_url = True
+    is_submission = False
 
     def url(self, name, parameters=None, expire=None):
-        if self.internal_url:
+        if self.is_submission:
             try:
                 name_parts = name.split('/')
-                # Create and return internal URL only for submissions
-                if name_parts[0] == 'submission':
-                    return reverse(
-                        'apply:submissions:private_media_redirect', kwargs={
-                            'submission_id': name_parts[1], 'field_id': name_parts[2],
-                            'file_name': name_parts[3]
-                        }
-                    )
+                return reverse(
+                    'apply:submissions:private_media_redirect', kwargs={
+                        'submission_id': name_parts[1], 'field_id': name_parts[2],
+                        'file_name': name_parts[3]
+                    }
+                )
             except IndexError:
                 pass
 

--- a/opentech/storage_backends.py
+++ b/opentech/storage_backends.py
@@ -29,12 +29,13 @@ class PrivateMediaStorage(S3Boto3Storage):
     file_overwrite = False
     querystring_auth = True
     url_protocol = 'https:'
+    internal_url = True
 
-    def url(self, name, parameters=None, expire=None, proxy_url=True):
-        if proxy_url:
+    def url(self, name, parameters=None, expire=None):
+        if self.internal_url:
             try:
                 name_parts = name.split('/')
-                # Create and return Proxy URL only for submissions
+                # Create and return internal URL only for submissions
                 if name_parts[0] == 'submission':
                     return reverse(
                         'apply:submissions:private_media_redirect', kwargs={


### PR DESCRIPTION
Closes #1168
Closes #637  
Closes #1108

The new URL for submission media can be accessed by users who have access to the submission detail view. The shareable URL will redirect to the actual file URL.