### PR TITLE
GH-1191 Make reviewer ordering consistent and tweak styles on tables

### DIFF
--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -180,7 +180,9 @@ class ApplicationSubmissionQueryset(JSONOrderable):
                 output_field=IntegerField(),
             ),
             review_submitted_count=Subquery(
-                reviewers.reviewed().values('submission').annotate(count=Count('pk', distinct=True)).values('count'),
+                reviewers.reviewed().exclude(opinions__opinion=DISAGREE).values('submission').annotate(
+                    count=Count('pk', distinct=True)
+                ).values('count'),
                 output_field=IntegerField(),
             ),
             review_recommendation=Case(

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -802,11 +802,17 @@ class AssignedReviewersQuerySet(models.QuerySet):
             type_order=models.Case(
                 *ordering,
                 output_field=models.IntegerField(),
+            ),
+            has_review=models.Case(
+                models.When(review__isnull=True, then=models.Value(1)),
+                models.When(review__is_draft=True, then=models.Value(1)),
+                default=models.Value(0),
+                output_field=models.IntegerField(),
             )
         ).order_by(
-            F('role__order').asc(nulls_last=True),
             'type_order',
-            F('review__pk').asc(nulls_last=True),
+            'has_review',
+            F('role__order').asc(nulls_last=True),
         ).select_related(
             'reviewer',
             'role',

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -180,7 +180,7 @@ class ApplicationSubmissionQueryset(JSONOrderable):
                 output_field=IntegerField(),
             ),
             review_submitted_count=Subquery(
-                reviewers.reviewed().exclude(opinions__opinion=DISAGREE).values('submission').annotate(
+                reviewers.reviewed().values('submission').annotate(
                     count=Count('pk', distinct=True)
                 ).values('count'),
                 output_field=IntegerField(),
@@ -820,13 +820,14 @@ class AssignedReviewersQuerySet(models.QuerySet):
 
     def reviewed(self):
         return self.filter(
-            Q(opinions__isnull=False) | Q(Q(review__isnull=False) & Q(review__is_draft=False))
+            Q(opinions__opinion=AGREE) |
+            Q(Q(review__isnull=False) & Q(review__is_draft=False))
         ).distinct()
 
     def not_reviewed(self):
         return self.filter(
             Q(review__isnull=True) | Q(review__is_draft=True),
-            opinions__isnull=True,
+            Q(opinions__isnull=True) | Q(opinions__opinion=DISAGREE),
         ).distinct()
 
     def never_tried_to_review(self):

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -7,7 +7,18 @@ from django.contrib.auth.models import Group
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import PermissionDenied
 from django.db import models
-from django.db.models import Case, Count, IntegerField, OuterRef, Subquery, Sum, Q, Prefetch, When
+from django.db.models import (
+    Case,
+    Count,
+    IntegerField,
+    F,
+    OuterRef,
+    Prefetch,
+    Q,
+    Subquery,
+    Sum,
+    When,
+)
 from django.db.models.expressions import RawSQL, OrderBy
 from django.db.models.functions import Coalesce
 from django.dispatch import receiver
@@ -791,9 +802,9 @@ class AssignedReviewersQuerySet(models.QuerySet):
                 output_field=models.IntegerField(),
             )
         ).order_by(
-            'role__order',
+            F('role__order').asc(nulls_last=True),
             'type_order',
-            'review',
+            F('review__pk').asc(nulls_last=True),
         ).select_related(
             'reviewer',
             'role',

--- a/opentech/apply/funds/templates/funds/includes/review_sidebar.html
+++ b/opentech/apply/funds/templates/funds/includes/review_sidebar.html
@@ -31,15 +31,4 @@
             {% endif %}
         {% endfor %}
     {% endfor %}
-
-    {% if reviews_block.external_reviewed or reviews_block.external_not_reviewed %}
-        {% for review_data in reviews_block.external_reviewed %}
-            {% include 'funds/includes/review_sidebar_item.html' with review=review_data.review reviewer=review_data.reviewer opinions=review_data.opinions %}
-        {% endfor %}
-
-        {% for review_data in reviews_block.external_not_reviewed %}
-            {% include 'funds/includes/review_sidebar_item.html' with reviewer=review_data.reviewer missing=True class="is-hidden" %}
-        {% endfor %}
-
-    {% endif %}
 </ul>

--- a/opentech/apply/funds/templates/funds/includes/review_sidebar_item.html
+++ b/opentech/apply/funds/templates/funds/includes/review_sidebar_item.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags %}
 
 <li class="reviews-sidebar__item {% if hidden and  not reviewer.review %}is-hidden {% endif %}{% if not reviewer.review %}no-response {% endif %}">
-    {% if not reviewer.review %}
+    {% if not reviewer.review or reviewer.review.is_draft %}
         <div class="reviews-sidebar__name">
             <span>{{ reviewer}}</span>
             {% if reviewer.role %}{% image reviewer.role.icon max-12x12 %}{% endif %}

--- a/opentech/apply/funds/templates/funds/tables/table.html
+++ b/opentech/apply/funds/templates/funds/tables/table.html
@@ -1,5 +1,5 @@
 {% extends 'django_tables2/table.html' %}
-{% load django_tables2 table_tags review_tags %}
+{% load django_tables2 table_tags review_tags wagtailimages_tags %}
 
 {% block table.tbody.row %}
     <tr {{ row.attrs.as_html }}>
@@ -36,20 +36,27 @@
                         <td>
                             <strong>{{ submission.screening_status|default:"Awaiting Screen status" }}</strong>
                         </td>
+
                         <td>
                             <ul class="list list--no-margin">
-                                {% for review in submission.reviews.submitted %}
+                                {% for reviewer in submission.has_reviewed %}
                                     <li class="list__item list__item--reviewer">
-                                        <span class="list__item--reviewer-name">{{ review.author }}</span>
-                                        <span class="list__item list__item--reviewer-outcome">{{ review.get_recommendation_display }}</span>
+                                        <span class="list__item--reviewer-name">
+                                            {{ reviewer }}
+                                            {% if reviewer.role %}{% image reviewer.role.icon max-12x12 %}{% endif %}
+                                        </span>
+                                        <span class="list__item list__item--reviewer-outcome">{{ reviewer.review.get_recommendation_display }}</span>
                                     </li>
-                                    {% for opinion in review.opinions.all %}
+                                    {% for opinion in reviewer.review.opinions.all %}
                                         {% if forloop.first %}
                                             <ul class="list list--opinion">
                                         {% endif %}
 
                                             <li class="list__item list__item--reviewer list__item--opinion">
-                                                <span class="list__item--reviewer-name">{{ opinion.author }}</span>
+                                                <span class="list__item--reviewer-name">
+                                                    {{ opinion.author }}
+                                                    {% if opinion.author.role %}{% image opinion.author.role.icon max-12x12 %}{% endif %}
+                                                </span>
                                                 <span class="list__item list__item--reviewer-outcome {{ opinion.get_opinion_display|lower }}">{{ opinion.get_opinion_display }}</span>
                                             </li>
 
@@ -58,9 +65,12 @@
                                         {% endif %}
                                     {% endfor %}
                                 {% endfor %}
-                                {% for reviewer in submission.staff_not_reviewed %}
+                                {% for reviewer in submission.hasnt_reviewed %}
                                     <li class="list__item list__item--reviewer">
-                                        <span class="list__item--reviewer-name">{{ reviewer }}</span>
+                                        <span class="list__item--reviewer-name">
+                                            {{ reviewer }}
+                                            {% if reviewer.role %}{% image reviewer.role.icon max-12x12 %}{% endif %}
+                                        </span>
                                         <span class="list__item list__item--reviewer-outcome">&mdash;</span>
                                     </li>
                                 {% endfor %}

--- a/opentech/apply/review/templates/review/review_list.html
+++ b/opentech/apply/review/templates/review/review_list.html
@@ -23,7 +23,9 @@
         <tr class="reviews-list__tr">
             <th class="reviews-list__th">{{ answers.question }}</th>
             {% for answer in answers.answers %}
-                {% if answers.question == "Opinions" %}
+                {% if forloop.parentloop.first %}
+                    <td class="reviews-list__td reviews-list__td--author">{{ answer|safe }}</td>
+                {% elif answers.question == "Opinions"%}
                     <td class="reviews-list__td">{{ answer }}</td>
                 {% else %}
                     <td class="reviews-list__td">{{ answer|bleach }}</td>

--- a/opentech/apply/review/views.py
+++ b/opentech/apply/review/views.py
@@ -267,8 +267,11 @@ class ReviewListView(ListView):
         review_data['comments'] = {'question': 'Comments', 'answers': list()}
 
         responses = self.object_list.count()
+        ordered_reviewers = AssignedReviewers.objects.filter(submission=self.submission).reviewed().review_order()
 
-        for i, review in enumerate(self.object_list):
+        reviews = {review.author: review for review in self.object_list}
+        for i, reviewer in enumerate(ordered_reviewers):
+            review = reviews[reviewer]
             author = '<a href="{}"><span>{}</span></a>'.format(review.get_absolute_url(), review.author)
             if review.author.role:
                 author += generate_image_tag(review.author.role.icon, '12x12')

--- a/opentech/apply/review/views.py
+++ b/opentech/apply/review/views.py
@@ -18,6 +18,7 @@ from opentech.apply.stream_forms.models import BaseStreamForm
 from opentech.apply.users.decorators import staff_required
 from opentech.apply.users.groups import REVIEWER_GROUP_NAME
 from opentech.apply.utils.views import CreateOrUpdateView
+from opentech.apply.utils.image import generate_image_tag
 
 from .models import Review
 from .options import DISAGREE
@@ -268,7 +269,12 @@ class ReviewListView(ListView):
         responses = self.object_list.count()
 
         for i, review in enumerate(self.object_list):
-            review_data['title']['answers'].append('<a href="{}">{}</a>'.format(review.get_absolute_url(), review.author))
+            author = '<a href="{}"><span>{}</span></a>'.format(review.get_absolute_url(), review.author)
+            if review.author.role:
+                author += generate_image_tag(review.author.role.icon, '12x12')
+            author = f'<div>{author}</div>'
+
+            review_data['title']['answers'].append(author)
             opinions_template = get_template('review/includes/review_opinions_list.html')
             opinions_html = opinions_template.render({'opinions': review.opinions.select_related('author').all()})
             review_data['opinions']['answers'].append(opinions_html)

--- a/opentech/static_src/src/sass/apply/components/_list.scss
+++ b/opentech/static_src/src/sass/apply/components/_list.scss
@@ -1,5 +1,6 @@
 .list {
     $root: &;
+    max-width: 290px;
 
     &--no-margin {
         margin: 0;
@@ -12,7 +13,6 @@
         border-bottom: 1px solid $color--mid-grey;
         margin: 10px 0;
         padding: 5px 0;
-        max-width: 150px;
 
         #{$root}__item--opinion:first-child {
             span:last-child {
@@ -39,14 +39,19 @@
         &--reviewer {
             display: flex;
             justify-content: space-between;
-            max-width: 150px;
         }
 
         &--reviewer-name {
-            max-width: 100px;
+            max-width: 190px;
             overflow: hidden;
             font-weight: $weight--bold;
             text-overflow: ellipsis;
+            display: flex;
+            align-items: center;
+
+            > img {
+                margin-left: 10px;
+            }
 
             // show truncated emails on hover
             &:hover {

--- a/opentech/static_src/src/sass/apply/components/_reviews-list.scss
+++ b/opentech/static_src/src/sass/apply/components/_reviews-list.scss
@@ -21,6 +21,17 @@
         max-width: 340px;
         min-width: 240px;
         padding: 20px;
+
+        &--author {
+            > div {
+                display: flex;
+                align-items: center;
+
+                img {
+                    margin-left: 7px;
+                }
+            }
+        }
     }
 
     &__th,


### PR DESCRIPTION
Current base is #985 - to be updated post merge

Tweaks the styling of the reviewers block in the table to give it more space and make the reviewer ordering logic consistent between all pages.

I've also snuck in #1205 because i was in the area. 

![image](https://user-images.githubusercontent.com/6338661/57715312-5e2d0680-766e-11e9-8ff2-5bb1f3fbb21e.png)
