### PR TITLE
Activate new accounts created after submissions directly and set a lo…

### DIFF
--- a/opentech/apply/users/models.py
+++ b/opentech/apply/users/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.db.models import Q
+from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -57,7 +58,10 @@ class UserManager(BaseUserManager.from_queryset(UserQuerySet)):
         return self._create_user(email, password, **extra_fields)
 
     def get_or_create_and_notify(self, defaults=dict(), site=None, **kwargs):
-        defaults.update(is_active=False)
+        # Set a temp password so users can access the password reset function if needed.
+        temp_pass = BaseUserManager().make_random_password(length=32)
+        temp_pass_hash = make_password(temp_pass)
+        defaults.update(password=temp_pass_hash)
         user, created = self.get_or_create(defaults=defaults, **kwargs)
         if created:
             send_activation_email(user, site)

--- a/opentech/apply/users/templates/users/activation/email.txt
+++ b/opentech/apply/users/templates/users/activation/email.txt
@@ -13,6 +13,8 @@ After setting your password, you will be able to log in at {% if site %}{{ site.
 username: {{ username }}
 password: Your chosen password
 
+If you do not complete the activation process within {{ timeout_days }} days you can use the password reset form at: {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{% url 'users:password_reset' %}
+
 Thanks,
 The OTF Team
 

--- a/opentech/apply/users/templates/users/change_password.html
+++ b/opentech/apply/users/templates/users/change_password.html
@@ -1,4 +1,4 @@
-{% extends 'base-apply.html' %}
+{% extends 'base.html' %}
 {% load i18n %}
 {% block header_modifier %}header--light-bg{% endblock %}
 {% block page_title %}Set a password{% endblock %}

--- a/opentech/apply/users/views.py
+++ b/opentech/apply/users/views.py
@@ -4,7 +4,6 @@ from django.contrib.auth import get_user_model, login, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AdminPasswordChangeForm
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
-from django.contrib.auth.models import BaseUserManager
 from django.contrib.auth.views import SuccessURLAllowedHostsMixin
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect, render, resolve_url
@@ -113,12 +112,6 @@ class ActivationView(TemplateView):
         user = self.get_user(kwargs.get('uidb64'))
 
         if self.valid(user, kwargs.get('token')):
-            user.is_active = True
-            # Set a temp password so users who skip setting one can use the password reset function.
-            temp_pass = BaseUserManager().make_random_password(length=32)
-            user.set_password(temp_pass)
-            user.save()
-
             user.backend = 'django.contrib.auth.backends.ModelBackend'
             login(request, user)
             return redirect('users:activate_password')
@@ -142,8 +135,7 @@ class ActivationView(TemplateView):
         """
         try:
             user = User.objects.get(**{
-                'pk': force_text(urlsafe_base64_decode(uidb64)),
-                'is_active': False
+                'pk': force_text(urlsafe_base64_decode(uidb64))
             })
             return user
         except (TypeError, ValueError, OverflowError, User.DoesNotExist):


### PR DESCRIPTION
…ng random password. This makes the password reset function work for new accounts even if they miss the activation e-mail.

Fixes #1275