### PR TITLE
API Key to access some endpoints

### DIFF
--- a/opentech/apply/funds/api_views.py
+++ b/opentech/apply/funds/api_views.py
@@ -9,6 +9,7 @@ from rest_framework import generics, mixins, permissions
 from rest_framework.response import Response
 from rest_framework.exceptions import (NotFound, PermissionDenied,
                                        ValidationError)
+from rest_framework_api_key.permissions import HasAPIKey
 from django_filters import rest_framework as filters
 
 from opentech.api.pagination import StandardResultsSetPagination
@@ -69,7 +70,7 @@ class SubmissionList(generics.ListAPIView):
     queryset = ApplicationSubmission.objects.current().with_latest_update()
     serializer_class = SubmissionListSerializer
     permission_classes = (
-        permissions.IsAuthenticated, IsApplyStaffUser,
+        HasAPIKey | permissions.IsAuthenticated, HasAPIKey | IsApplyStaffUser,
     )
     filter_backends = (filters.DjangoFilterBackend,)
     filter_class = SubmissionsFilter

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -125,6 +125,7 @@ INSTALLED_APPS = [
     'django_otp.plugins.otp_static',
     'two_factor',
     'rest_framework',
+    'rest_framework_api_key',
     'wagtailcache',
 
     'hijack',

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ django-two-factor-auth==1.9.1
 django-webpack-loader==0.6.0
 django_select2==7.1.0
 djangorestframework==3.9.2
+djangorestframework-api-key==1.3.0
 django==2.1.11
 gunicorn==19.9.0
 mailchimp3==3.0.7


### PR DESCRIPTION
Closes #974 

API keys can be generated from `/django-admin/rest_framework_api_key/apikey/`

The generated API key will be shown only once while creating for better security. So, the admin user must note it down.

@frjo Initial PR for issue #974. OTF can test it and then we can make further enhancements. For testing, allowed one endpoint 

```
curl -X GET http://apply.localhost:8000/apply/api/submissions/ -H 'Authorization: Api-Key CHANGE-WITH-GENERATED-KEY'
```