### PR TITLE
Sanitising submission revision output before diff

### DIFF
--- a/opentech/apply/funds/differ.py
+++ b/opentech/apply/funds/differ.py
@@ -29,16 +29,16 @@ def compare(answer_a, answer_b, should_bleach=True):
 
     if should_bleach:
         if isinstance(answer_a, str):
-            answer_a = bleach.clean(answer_a)
+            answer_a = bleach.clean(answer_a, tags=['section', 'h4', 'p', 'br'], attributes={}, strip=True)
         else:
             answer_a = str(answer_a)
 
         if isinstance(answer_b, str):
-            answer_b = bleach.clean(answer_b)
+            answer_b = bleach.clean(answer_b, tags=['section', 'h4', 'p', 'br'], attributes={}, strip=True)
         else:
             answer_b = str(answer_b)
 
-    diff = SequenceMatcher(lambda x: '\n' in x, answer_a, answer_b)
+    diff = SequenceMatcher(lambda x: '\n\r' in x, answer_a, answer_b)
     output = []
     added = []
     deleted = []

--- a/opentech/apply/funds/differ.py
+++ b/opentech/apply/funds/differ.py
@@ -1,7 +1,6 @@
+from bleach.sanitizer import Cleaner
 from bs4 import BeautifulSoup
 from difflib import SequenceMatcher
-
-import bleach
 
 from django.utils.html import format_html
 from django.utils.text import mark_safe
@@ -28,17 +27,18 @@ def compare(answer_a, answer_b, should_bleach=True):
         return answer_b
 
     if should_bleach:
+        cleaner = Cleaner(tags=['h4'], attributes={}, strip=True)
         if isinstance(answer_a, str):
-            answer_a = bleach.clean(answer_a, tags=['section', 'h4', 'p', 'br'], attributes={}, strip=True)
+            answer_a = cleaner.clean(answer_a)
         else:
             answer_a = str(answer_a)
 
         if isinstance(answer_b, str):
-            answer_b = bleach.clean(answer_b, tags=['section', 'h4', 'p', 'br'], attributes={}, strip=True)
+            answer_b = cleaner.clean(answer_b)
         else:
             answer_b = str(answer_b)
 
-    diff = SequenceMatcher(lambda x: '\n\r' in x, answer_a, answer_b)
+    diff = SequenceMatcher(None, answer_a, answer_b)
     output = []
     added = []
     deleted = []

--- a/opentech/apply/funds/templates/funds/applicationrevision_list.html
+++ b/opentech/apply/funds/templates/funds/applicationrevision_list.html
@@ -14,7 +14,7 @@
         {% for revision in object_list %}
             <li class="revision__item">
                 <p class="revision__meta">
-                    <span class="revision__date">{{ revision.timestamp|date:"m.d.y h:iA e"}} </span>
+                    <span class="revision__date">{{ revision.timestamp|date:"Y-m-d H:i e"}} </span>
                     by {{ revision.author }}
                     {% if forloop.first %}
                         <span class="revision__current">- current</span>

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -809,7 +809,7 @@ class RevisionCompareView(DetailView):
 
         # Compare all the answers
         diffed_text_fields_answers = [
-            compare(*fields, should_bleach=False)
+            compare(*fields, should_bleach=True)
             for fields in zip(from_rendered_text_fields, to_rendered_text_fields)
         ]
 

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -801,7 +801,7 @@ class RevisionCompareView(DetailView):
 
         # Compare all the required fields
         diffed_required = [
-            compare(*fields, should_bleach=False)
+            compare(*fields)
             for fields in zip(from_required, to_required)
         ]
         for field, diff in zip(self.object.named_blocks, diffed_required):
@@ -809,7 +809,7 @@ class RevisionCompareView(DetailView):
 
         # Compare all the answers
         diffed_text_fields_answers = [
-            compare(*fields, should_bleach=True)
+            compare(*fields)
             for fields in zip(from_rendered_text_fields, to_rendered_text_fields)
         ]
 


### PR DESCRIPTION
Fixes #1299

Only allowing h4 (field labels), everything else is stripped. This allows the diff to concentrate on the text content.