### PR TITLE
Link Rounds to Related Items

### DIFF
--- a/opentech/apply/funds/admin.py
+++ b/opentech/apply/funds/admin.py
@@ -32,7 +32,7 @@ class RoundAdmin(BaseRoundAdmin):
     def applications(self, obj):
         def build_urls(applications):
             for application in applications:
-                url = self.get_other_admin_edit_url(application.form)
+                url = reverse('funds_applicationform_modeladmin_edit', args=[application.id])
                 yield f'<a href="{url}">{application}</a>'
 
         urls = list(build_urls(obj.forms.all()))
@@ -47,22 +47,10 @@ class RoundAdmin(BaseRoundAdmin):
         url_tag = f'<a href="{url}">{obj.fund}</a>'
         return mark_safe(url_tag)
 
-    def get_other_admin_edit_url(self, obj):
-        """
-        Build an admin URL for the given obj.
-
-        This builds a ModelAdmin URL for the given object, mirroring Wagtail's
-        ModelAdmin.url_helper.get_action_url but works for any ModelAdmin.
-        """
-        app_label = obj._meta.app_label
-        model_name = obj._meta.model_name
-        url_name = f'{app_label}_{model_name}_modeladmin_edit'
-        return reverse(url_name, args=[obj.id])
-
     def review_forms(self, obj):
         def build_urls(review_forms):
             for review_form in review_forms:
-                url = self.get_other_admin_edit_url(review_form)
+                url = reverse('funds_round_modeladmin_edit', args=[review_form.id])
                 yield f'<a href="{url}">{review_form}</a>'
 
         urls = list(build_urls(obj.review_forms.all()))

--- a/opentech/apply/funds/admin.py
+++ b/opentech/apply/funds/admin.py
@@ -1,3 +1,4 @@
+from django.utils.safestring import mark_safe
 from wagtail.contrib.modeladmin.helpers import PermissionHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup
 
@@ -26,6 +27,12 @@ class RoundAdmin(BaseRoundAdmin):
     model = Round
     menu_icon = 'repeat'
     list_display = ('title', 'fund', 'start_date', 'end_date', 'sealed')
+
+
+    def fund(self, obj):
+        url = self.url_helper.get_action_url('edit', obj.fund.id)
+        url_tag = f'<a href="{url}">{obj.fund}</a>'
+        return mark_safe(url_tag)
 
 
 class ScreeningStatusPermissionHelper(PermissionHelper):

--- a/opentech/apply/funds/admin.py
+++ b/opentech/apply/funds/admin.py
@@ -16,7 +16,6 @@ from opentech.apply.categories.admin import CategoryAdmin, MetaCategoryAdmin
 class BaseRoundAdmin(ModelAdmin):
     choose_parent_view_class = RoundFundChooserView
     choose_parent_template_name = 'funds/admin/parent_chooser.html'
-    list_display = ('title', 'fund', 'start_date', 'end_date')
     button_helper_class = ButtonsWithPreview
 
     def fund(self, obj):
@@ -26,6 +25,7 @@ class BaseRoundAdmin(ModelAdmin):
 class RoundAdmin(BaseRoundAdmin):
     model = Round
     menu_icon = 'repeat'
+    list_display = ('title', 'fund', 'start_date', 'end_date', 'sealed')
 
 
 class ScreeningStatusPermissionHelper(PermissionHelper):
@@ -54,6 +54,7 @@ class SealedRoundAdmin(BaseRoundAdmin):
     model = SealedRound
     menu_icon = 'locked'
     menu_label = 'Sealed Rounds'
+    list_display = ('title', 'fund', 'start_date', 'end_date')
 
 
 class FundAdmin(ModelAdmin):

--- a/opentech/apply/funds/admin.py
+++ b/opentech/apply/funds/admin.py
@@ -27,7 +27,7 @@ class BaseRoundAdmin(ModelAdmin):
 class RoundAdmin(BaseRoundAdmin):
     model = Round
     menu_icon = 'repeat'
-    list_display = ('title', 'fund', 'start_date', 'end_date', 'sealed', 'applications')
+    list_display = ('title', 'fund', 'start_date', 'end_date', 'sealed', 'applications', 'review_forms')
 
     def applications(self, obj):
         def build_urls(applications):
@@ -58,6 +58,19 @@ class RoundAdmin(BaseRoundAdmin):
         model_name = obj._meta.model_name
         url_name = f'{app_label}_{model_name}_modeladmin_edit'
         return reverse(url_name, args=[obj.id])
+
+    def review_forms(self, obj):
+        def build_urls(review_forms):
+            for review_form in review_forms:
+                url = self.get_other_admin_edit_url(review_form)
+                yield f'<a href="{url}">{review_form}</a>'
+
+        urls = list(build_urls(obj.review_forms.all()))
+
+        if not urls:
+            return
+
+        return mark_safe('<br />'.join(urls))
 
 
 class ScreeningStatusPermissionHelper(PermissionHelper):


### PR DESCRIPTION
This adds three columns to the Rounds admin page with links to the relevant related content:

* Sealed
* Applications
* Review Forms

It also converts the Fund column to a link as well.

Fixes #549 