### PR TITLE
IE 11 does not support classList.replace making wysiwyg textareas hid…

### DIFF
--- a/opentech/static_src/src/javascript/main.js
+++ b/opentech/static_src/src/javascript/main.js
@@ -3,6 +3,10 @@
 
     'use strict';
 
+    // IE 11 does not support classList.replace.
+    // document.querySelector('html').classList.replace('no-js', 'js');
+    $('html').removeClass('no-js').addClass('js');
+
     let Search = class {
         static selector() {
             return '.js-search-toggle';

--- a/opentech/templates/base-apply.html
+++ b/opentech/templates/base-apply.html
@@ -24,9 +24,6 @@
         <meta name="msapplication-TileImage" content="{% static 'images/favicons/mstile-150.png' %}">
         <meta name="theme-color" content="#ffffff">
         <link rel="mask-icon" href="{% static 'images/favicons/safari-pinned-tab.svg' %}" color="#5bbad5">
-
-        <script>document.querySelector('html').classList.replace('no-js', 'js');</script>
-
         <link rel="stylesheet" href="{% static 'css/normalize.css' %}">
         <link rel="stylesheet" href="{% static 'css/apply/main.css' %}">
         {# Hijack styling #}

--- a/opentech/templates/base.html
+++ b/opentech/templates/base.html
@@ -52,8 +52,6 @@
         <meta property="og:description" content="{{ page|social_text:request.site }}" />
         <meta property="og:site_name" content="{{ settings.utils.SocialMediaSettings.site_name }}" />
 
-        <script>document.querySelector('html').classList.replace('no-js', 'js');</script>
-
         <link rel="stylesheet" href="{% static 'css/normalize.css' %}">
         <link rel="stylesheet" href="{% static 'css/public/main.css' %}">
         {% block extra_css %}{% endblock %}


### PR DESCRIPTION
…den. Use jQuery for now to to the no-js -> js class replacing.

Fixes #1320