### PR TITLE
Create Project on Accepted Determination

### DIFF
--- a/opentech/apply/determinations/tests/test_views.py
+++ b/opentech/apply/determinations/tests/test_views.py
@@ -126,6 +126,143 @@ class DeterminationFormTestCase(BaseViewTestCase):
         self.assertEqual(submission_original.status, 'invited_to_proposal')
         self.assertEqual(submission_next.status, 'draft_proposal')
 
+    def test_first_stage_accepted_determination_does_not_create_project(self):
+        submission = ApplicationSubmissionFactory(
+            status='concept_review_discussion',
+            workflow_stages=2,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': ACCEPTED,
+            'message': 'You are invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+
+        self.assertIsNotNone(submission_next)
+
+        # Confirm a Project was not created for either submission since it's
+        # not in the final stage of its workflow.
+        self.assertFalse(hasattr(submission_original, 'project'))
+        self.assertFalse(hasattr(submission_next, 'project'))
+
+    def test_first_stage_rejected_determination_does_not_create_project(self):
+        submission = ApplicationSubmissionFactory(
+            status='concept_review_discussion',
+            workflow_stages=2,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': REJECTED,
+            'message': 'You are not invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+
+        # There should be no next submission since rejected is an end to the
+        # applications flow.
+        self.assertIsNone(submission_next)
+
+        # Confirm a Project was not created for the original
+        # ApplicationSubmission.
+        self.assertFalse(hasattr(submission_original, 'project'))
+
+    def test_second_stage_accepted_determination_creates_project(self):
+        submission = ApplicationSubmissionFactory(
+            status='proposal_determination',
+            workflow_stages=2,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': ACCEPTED,
+            'message': 'You are invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+        # import ipdb;ipdb.set_trace()
+
+        # There should be no next submission since rejected is an end to the
+        # applications flow.
+        self.assertIsNone(submission_next)
+
+        self.assertTrue(hasattr(submission_original, 'project'))
+        self.assertFalse(hasattr(submission_next, 'project'))
+
+    def test_second_stage_rejected_determination_does_not_create_project(self):
+        submission = ApplicationSubmissionFactory(
+            status='proposal_determination',
+            workflow_stages=2,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': REJECTED,
+            'message': 'You are not invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+
+        # There should be no next submission since rejected is an end to the
+        # applications flow.
+        self.assertIsNone(submission_next)
+
+        self.assertFalse(hasattr(submission_original, 'project'))
+
+    def test_single_stage_accepted_determination_creates_project(self):
+        submission = ApplicationSubmissionFactory(
+            status='post_review_discussion',
+            workflow_stages=1,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': ACCEPTED,
+            'message': 'You are invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+
+        self.assertIsNone(submission_next)
+        self.assertTrue(hasattr(submission_original, 'project'))
+
+    def test_single_stage_rejected_determination_does_not_create_project(self):
+        submission = ApplicationSubmissionFactory(
+            status='post_review_discussion',
+            workflow_stages=1,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': REJECTED,
+            'message': 'You are not invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+
+        self.assertIsNone(submission_next)
+        self.assertFalse(hasattr(submission_original, 'project'))
+
 
 class BatchDeterminationTestCase(BaseViewTestCase):
     user_factory = StaffFactory

--- a/opentech/apply/determinations/views.py
+++ b/opentech/apply/determinations/views.py
@@ -258,6 +258,10 @@ class DeterminationCreateOrUpdateView(CreateOrUpdateView):
                     related_object=self.object,
                 )
 
+            # Grab this before transitioning so we can decide to make a Project
+            # based on the Submissions current state, not it's post-transition one.
+            in_final_stage = self.submission.in_final_stage
+
             self.submission.perform_transition(
                 transition,
                 self.request.user,
@@ -265,7 +269,7 @@ class DeterminationCreateOrUpdateView(CreateOrUpdateView):
                 notify=False,
             )
 
-            if self.object.outcome == ACCEPTED:
+            if self.object.outcome == ACCEPTED and in_final_stage:
                 Project.create_from_submission(self.submission)
 
         messenger(

--- a/opentech/apply/determinations/views.py
+++ b/opentech/apply/determinations/views.py
@@ -15,6 +15,7 @@ from opentech.apply.activity.models import Activity
 from opentech.apply.activity.messaging import messenger, MESSAGES
 from opentech.apply.funds.models import ApplicationSubmission
 from opentech.apply.funds.workflow import DETERMINATION_OUTCOMES
+from opentech.apply.projects.models import Project
 from opentech.apply.utils.views import CreateOrUpdateView, ViewDispatcher
 from opentech.apply.users.decorators import staff_required
 
@@ -24,7 +25,7 @@ from .forms import (
     ConceptDeterminationForm,
     ProposalDeterminationForm,
 )
-from .models import Determination, DeterminationMessageSettings, NEEDS_MORE_INFO, TRANSITION_DETERMINATION
+from .models import Determination, DeterminationMessageSettings, NEEDS_MORE_INFO, TRANSITION_DETERMINATION, ACCEPTED
 
 from .utils import (
     can_create_determination,
@@ -268,6 +269,9 @@ class DeterminationCreateOrUpdateView(CreateOrUpdateView):
             request=self.request,
             notify=False,
         )
+
+        if self.object.outcome == ACCEPTED:
+            Project.create_from_submission(self.submission)
 
         return HttpResponseRedirect(self.submission.get_absolute_url())
 

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -693,6 +693,17 @@ class ApplicationSubmission(
     def __repr__(self):
         return f'<{self.__class__.__name__}: {self.user}, {self.round}, {self.page}>'
 
+    @property
+    def in_final_stage(self):
+        stages = self.workflow.stages
+
+        stage_index = stages.index(self.stage)
+
+        # adjust the index since list.index() is zero-based
+        adjusted_index = stage_index + 1
+
+        return adjusted_index == len(stages)
+
     # Methods for accessing data on the submission
 
     def get_data(self):

--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -22,6 +22,7 @@ from .factories import (
     AssignedReviewersFactory,
     CustomFormFieldsFactory,
     FundTypeFactory,
+    InvitedToProposalFactory,
     LabFactory,
     RequestForPartnersFactory,
     RoundFactory,
@@ -451,6 +452,13 @@ class TestApplicationSubmission(TestCase):
 
         submission.create_revision(draft=True)
         self.assertEqual(submission.revisions.count(), 2)
+
+    def test_in_final_stage(self):
+        submission = InvitedToProposalFactory().previous
+        self.assertFalse(submission.in_final_stage)
+
+        submission = InvitedToProposalFactory()
+        self.assertTrue(submission.in_final_stage)
 
 
 class TestSubmissionRenderMethods(TestCase):

--- a/opentech/apply/funds/workflow.py
+++ b/opentech/apply/funds/workflow.py
@@ -109,7 +109,7 @@ class Phase:
         return self.display_name
 
     def __repr__(self):
-        return f'<Phase {self.display_name} ({self.public_name})>'
+        return f'<Phase: {self.display_name} ({self.public_name})>'
 
 
 class Stage:
@@ -119,6 +119,9 @@ class Stage:
 
     def __str__(self):
         return self.name
+
+    def __repr__(self):
+        return f'<Stage: {self.name}>'
 
 
 class Permissions:


### PR DESCRIPTION
This creates a Project when an accepted Determination is applied to a submission.

I took the opportunity to refactor the `.form_valid()` method to add a fast failure condition to make it clearer that draft submissions are ignored.

Ref #1343