### PR TITLE
Move demo funding/payment/invoice blocks to the project page

### DIFF
--- a/opentech/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/opentech/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -90,13 +90,6 @@
 
                     {% include "funds/includes/rendered_answers.html" %}
 
-                    <div class="wrapper wrapper--outer-space-large">
-                        {% include "funds/includes/funding_block.html" %}
-                        {% include "funds/includes/payment_requests.html" %}
-                        {% include "funds/includes/invoice_block.html" %}
-                    </div>
-
-                    {# {% include "funds/includes/supporting_documents.html" %} #}
                 </article>
             {% endif %}
 

--- a/opentech/apply/projects/templates/application_projects/project_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_detail.html
@@ -122,6 +122,12 @@
                     </div>
                 </div>
 
+                {# <div class="wrapper wrapper--outer-space-large"> #}
+                {#     {% include "funds/includes/funding_block.html" %} #}
+                {#     {% include "funds/includes/payment_requests.html" %} #}
+                {#     {% include "funds/includes/invoice_block.html" %} #}
+                {# </div> #}
+
                 {% include "application_projects/includes/supporting_documents.html" %}
             </article>
 


### PR DESCRIPTION
This moves the Funding, Payment, & Invoice blocks from the Submission page to the Project page, leaving them hidden.