### PR TITLE
Rename Program Manager -> Lead

### DIFF
--- a/opentech/apply/projects/templates/application_projects/project_admin_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_admin_detail.html
@@ -37,7 +37,7 @@
        data-src="#assign-lead"
        class="button button--bottom-space button--white button--full-width"
        href="#">
-        Program Manager
+        Lead
     </a>
 
     <a data-fancybox


### PR DESCRIPTION
Fixes incorrect copy on the assign-a-lead button as per [here](https://github.com/OpenTechFund/opentech.fund/issues/1328#issuecomment-518265160)