### PR TITLE
Confirm Project Approval with Missing Categories

### DIFF
--- a/opentech/apply/funds/templates/funds/includes/delegated_form_base.html
+++ b/opentech/apply/funds/templates/funds/includes/delegated_form_base.html
@@ -5,6 +5,23 @@
         {{ form }}
     </div>
 
-    <input class="button button--primary button--top-space" id="{{ form.name }}-submit" name="{{ form_prefix }}{{ form.name }}" type="submit" form="{{ form.name }}" value="{{ value }}">
+    {% if cancel %}
+    <button
+        type="button"
+        data-fancybox-close=""
+        class="button button--{% if invert %}primary{% else %}white{% endif %} button--top-space"
+        title="Close">
+        Cancel
+    </button>
+    {% endif %}
+
+    <input
+        class="button button--{% if invert %}white{% else %}primary{% endif %} button--top-space"
+        id="{{ form.name }}-submit"
+        name="{{ form_prefix }}{{ form.name }}"
+        type="submit"
+        form="{{ form.name }}"
+        value="{{ value }}"
+    >
 
 </form>

--- a/opentech/apply/projects/templates/application_projects/project_admin_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_admin_detail.html
@@ -6,7 +6,44 @@
 {% block admin_sidebar %}
 <div class="modal" id="send-for-approval">
     <h4 class="modal__header-bar">Request Approval</h4>
+
+    {% if not remaining_document_categories %}
     {% include 'funds/includes/delegated_form_base.html' with form=request_approval_form value='Request'%}
+    {% else %}
+    <form class="form" method="post" id="{{ request_approval_form.name }}">
+        {% csrf_token %}
+
+        <h5>Are you sure you're ready to upload?</h5>
+
+        <p>This project is missing the following documents:</p>
+
+        <ul>
+            {% for missing in remaining_document_categories %}
+            <li><strong>{{ missing.category.name }} ({{ missing.difference }})</strong></li>
+            {% endfor %}
+        </ul>
+
+        <div class="form__item">
+            {{ request_approval_form }}
+        </div>
+
+        <button
+            type="button"
+            data-fancybox-close=""
+            class="button button--primary button--top-space"
+            title="Close">
+            Cancel
+        </button>
+
+        <input
+            class="button button--white button--top-space"
+            id="{{ request_approval_form.name }}-submit"
+            name="{{ form_prefix }}{{ request_approval_form.name }}"
+            type="submit" form="{{ form.name }}"
+            value="Upload anyway" />
+
+    </form>
+    {% endif %}
 </div>
 
 <div class="modal" id="assign-lead">

--- a/opentech/apply/projects/templates/application_projects/project_admin_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_admin_detail.html
@@ -7,13 +7,8 @@
 <div class="modal" id="send-for-approval">
     <h4 class="modal__header-bar">Request Approval</h4>
 
-    {% if not remaining_document_categories %}
-    {% include 'funds/includes/delegated_form_base.html' with form=request_approval_form value='Request'%}
-    {% else %}
-    <form class="form" method="post" id="{{ request_approval_form.name }}">
-        {% csrf_token %}
-
-        <h5>Are you sure you're ready to upload?</h5>
+    {% if remaining_document_categories %}
+        <h5>Are you sure you're ready to submit?</h5>
 
         <p>This project is missing the following documents:</p>
 
@@ -22,27 +17,9 @@
             <li><strong>{{ missing.category.name }} ({{ missing.difference }})</strong></li>
             {% endfor %}
         </ul>
-
-        <div class="form__item">
-            {{ request_approval_form }}
-        </div>
-
-        <button
-            type="button"
-            data-fancybox-close=""
-            class="button button--primary button--top-space"
-            title="Close">
-            Cancel
-        </button>
-
-        <input
-            class="button button--white button--top-space"
-            id="{{ request_approval_form.name }}-submit"
-            name="{{ form_prefix }}{{ request_approval_form.name }}"
-            type="submit" form="{{ form.name }}"
-            value="Upload anyway" />
-
-    </form>
+        {% include 'funds/includes/delegated_form_base.html' with form=request_approval_form value='Submit anyway' cancel=True invert=True %}
+    {% else %}
+        {% include 'funds/includes/delegated_form_base.html' with form=request_approval_form value='Request' %}
     {% endif %}
 </div>
 

--- a/opentech/apply/projects/views.py
+++ b/opentech/apply/projects/views.py
@@ -163,7 +163,7 @@ class AdminProjectDetailView(ActivityContextMixin, DelegateableView, DetailView)
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['approvals'] = self.object.approvals.distinct('by')
-        context['remaining_document_categories'] = self.object.get_missing_document_categories()
+        context['remaining_document_categories'] = list(self.object.get_missing_document_categories())
         return context
 
 


### PR DESCRIPTION
This displays a warning to a user when they request Approval on a Project but haven't uploaded the recommended number of documents in each category.

Ref #1345 