### PR TITLE
Feature/updates from demo 1

### DIFF
--- a/addressfield/fields.py
+++ b/addressfield/fields.py
@@ -14,6 +14,10 @@ with open(filepath, encoding='utf8') as address_data:
 
 VALIDATION_DATA = {country['iso']: country for country in countries}
 
+ADDRESS_FIELDS_ORDER = [
+    'thoroughfare', 'premise', 'localityname', 'administrativearea', 'postalcode', 'country'
+]
+
 
 def flatten_data(data):
     flattened = dict()

--- a/opentech/apply/activity/templates/messages/email/applicant_base.html
+++ b/opentech/apply/activity/templates/messages/email/applicant_base.html
@@ -1,7 +1,7 @@
 {% extends "messages/email/base.html" %}
 {% block salutation %}Dear {{ source.user.get_full_name|default:"applicant" }},{% endblock %}
 
-{% block more_info %}You can access your application here: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
+{% block more_info %}You can find more information here: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}
 If you have any questions, please submit them here: {{ request.scheme }}://{{ request.get_host }}{{ source.get_absolute_url }}#communications
 
 If you have any issues accessing the submission system or other general inquiries, please email us at hello@opentech.fund

--- a/opentech/apply/activity/templates/messages/email/comment.html
+++ b/opentech/apply/activity/templates/messages/email/comment.html
@@ -1,5 +1,5 @@
 {% extends "messages/email/applicant_base.html" %}
 
-{% block content %}There has been a new comment on your application: {{ source.title }}
+{% block content %}There has been a new comment on "{{ source.title }}"
 
 {{ comment.user }}: {{ comment.message }}{% endblock %}

--- a/opentech/apply/funds/blocks.py
+++ b/opentech/apply/funds/blocks.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from wagtail.core import blocks
 
-from addressfield.fields import AddressField
+from addressfield.fields import AddressField, ADDRESS_FIELDS_ORDER
 from opentech.apply.categories.blocks import CategoryQuestionBlock
 from opentech.apply.stream_forms.blocks import FormFieldsBlock
 from opentech.apply.utils.blocks import (
@@ -69,18 +69,15 @@ class AddressFieldBlock(ApplicationSingleIncludeFieldBlock):
         # Based on the fields listed in addressfields/widgets.py
         return ', '.join(
             data[field]
-            for field in order_fields
+            for field in ADDRESS_FIELDS_ORDER
             if data[field]
         )
 
     def prepare_data(self, value, data, serialize):
-        order_fields = [
-            'thoroughfare', 'premise', 'localityname', 'administrativearea', 'postalcode', 'country'
-        ]
         data = json.loads(data)
         data = {
             field: data[field]
-            for field in order_fields
+            for field in ADDRESS_FIELDS_ORDER
         }
 
         if serialize:

--- a/opentech/apply/funds/templates/funds/applicationsubmission_admin_detail.html
+++ b/opentech/apply/funds/templates/funds/applicationsubmission_admin_detail.html
@@ -36,10 +36,6 @@
     </div>
 {% endblock %}
 
-{% block project %}
-    {% include 'funds/includes/project_block.html' %}
-{% endblock %}
-
 {% block screening_status %}
     {% include 'funds/includes/screening_status_block.html' %}
 {% endblock %}

--- a/opentech/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/opentech/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -99,9 +99,8 @@
                     {% endblock %}
                 {% endif %}
 
-                {% if request.user.is_apply_staff and object.project %}
-                    {% block project %}
-                    {% endblock %}
+                {% if object.project %}
+                    {% include 'funds/includes/project_block.html' %}
                 {% endif %}
 
                 {% block determination %}

--- a/opentech/apply/projects/forms.py
+++ b/opentech/apply/projects/forms.py
@@ -61,6 +61,8 @@ class ProjectEditForm(forms.ModelForm):
             'proposed_start': forms.DateInput,
         }
 
+
+class ProjectApprovalForm(ProjectEditForm):
     def save(self, *args, **kwargs):
         self.instance.user_has_updated_details = True
         return super().save(*args, **kwargs)

--- a/opentech/apply/projects/models.py
+++ b/opentech/apply/projects/models.py
@@ -105,9 +105,9 @@ class Project(models.Model):
     def get_address_display(self):
         address = json.loads(self.contact_address)
         return ', '.join(
-            address[field]
+            address.get(field)
             for field in ADDRESS_FIELDS_ORDER
-            if address[field]
+            if address.get(field)
         )
 
     @classmethod

--- a/opentech/apply/projects/models.py
+++ b/opentech/apply/projects/models.py
@@ -134,6 +134,14 @@ class Project(models.Model):
         if self.proposed_start > self.proposed_end:
             raise ValidationError(_('Proposed End Date must be after Proposed Start Date'))
 
+    def editable_by(self, user):
+        if self.editable:
+            return True
+
+        # Approver can edit it when they are approving
+        return user.is_approver and self.can_make_approval
+
+    @property
     def editable(self):
         # Someone must lead the project to make changes
         return self.lead and not self.is_locked

--- a/opentech/apply/projects/models.py
+++ b/opentech/apply/projects/models.py
@@ -1,6 +1,8 @@
 import collections
 import decimal
+import json
 
+from addressfield.fields import ADDRESS_FIELDS_ORDER
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
@@ -99,6 +101,14 @@ class Project(models.Model):
 
     def __str__(self):
         return self.title
+
+    def get_address_display(self):
+        address = json.loads(self.contact_address)
+        return ', '.join(
+            address[field]
+            for field in ADDRESS_FIELDS_ORDER
+            if address[field]
+        )
 
     @classmethod
     def create_from_submission(cls, submission):

--- a/opentech/apply/projects/templates/application_projects/includes/supporting_documents.html
+++ b/opentech/apply/projects/templates/application_projects/includes/supporting_documents.html
@@ -1,3 +1,6 @@
+{% load approval_tools %}
+{% user_can_edit_project object request.user as editable %}
+
 <div class="docs-block wrapper--outer-space-large">
     <div class="docs-block__header">
         <h4 class="docs-block__heading">Supporting documents</h4>
@@ -23,7 +26,7 @@
                 <p class="docs-block__title">Approval Form</p>
             </div>
             <div class="docs-block__row-inner">
-                {% if object.editable %}
+                {% if editable %}
                     <a class="docs-block__link" href="{% url 'apply:projects:edit' pk=object.pk %}">
                         {% if object.user_has_updated_details %}
                         Edit
@@ -45,7 +48,7 @@
                 <svg class="icon docs-block__icon"><use xlink:href="#tick"></use></svg>
                 <p class="docs-block__title">Supporting documents</p>
             </div>
-            {% if object.editable %}
+            {% if editable %}
                 <div class="docs-block__row-inner">
                     <a data-fancybox data-src="#upload-supporting-doc" class="docs-block__link" href="#">Upload new</a>
                 </div>

--- a/opentech/apply/projects/templates/application_projects/project_applicant_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_applicant_detail.html
@@ -1,0 +1,18 @@
+{% extends "application_projects/project_detail.html" %}
+
+{% block notifications %}
+{% if not object.editable %}
+<div class="wrapper wrapper--sidebar">
+    <div class="wrapper--sidebar--inner wrapper--error">
+        <div>
+            <p>Your project is not editable at this point.</p>
+            {% if not object.lead %}
+                <p>We are awaiting a lead to be assigned.</p>
+            {% else %}
+                <p>It is currently under review by a staff member.</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/opentech/apply/projects/templates/application_projects/project_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_detail.html
@@ -56,26 +56,10 @@
 
 <div class="wrapper wrapper--large wrapper--tabs js-tabs-content">
     <div class="tabs__content" id="tab-1">
-
+        {% block notifications %}
+        {% endblock %}
         <div class="wrapper wrapper--sidebar">
             <article class="wrapper--sidebar--inner">
-                <header class="heading heading--submission-meta heading-text zeta">
-                    <span>Last edit: <strong>{{ object.updated_at.timestamp.date }} by {{ object.updated_by }}</strong></span>
-
-                    {# {% if request.user|has_edit_perm:object %} #}
-                    {% if request.user %}
-                    <a class="link link--edit-submission is-active" href="#">
-                        Edit
-                        <svg class="icon icon--pen"><use xlink:href="#pen"></use></svg>
-                    </a>
-                    {% else %}
-                    <span class="link link--edit-submission">
-                        Edit
-                        <svg class="icon icon--padlock"><use xlink:href="#padlock"></use></svg>
-                    </span>
-                    {% endif %}
-                </header>
-
                 <h3>Project Information</h3>
                 <div class="grid grid--proposal-info">
                     <div>
@@ -128,9 +112,7 @@
                 {#     {% include "funds/includes/invoice_block.html" %} #}
                 {# </div> #}
 
-                {% if request.user.is_apply_staff %}
-                    {% include "application_projects/includes/supporting_documents.html" %}
-                {% endif %}
+                {% include "application_projects/includes/supporting_documents.html" %}
             </article>
 
             <aside class="sidebar">

--- a/opentech/apply/projects/templates/application_projects/project_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_detail.html
@@ -92,7 +92,7 @@
                 <div class="rich-text--hidden js-rich-text-hidden">
                     <div>
                         <h5>Address</h5>
-                        <p>{{ object.contact_address|default:"-" }}</p>
+                        <p>{{ object.get_address_display|default:"-"}}</p>
                     </div>
 
                     <div>
@@ -102,7 +102,7 @@
 
                     <div>
                         <h5>Value</h5>
-                        <p>{{ object.value|default:"-" }}</p>
+                        <p>${{ object.value|default:"-" }}</p>
                     </div>
                 </div>
 

--- a/opentech/apply/projects/templates/application_projects/project_form.html
+++ b/opentech/apply/projects/templates/application_projects/project_form.html
@@ -2,12 +2,12 @@
 
 {% load static %}
 
-{% block title %}Editing: {{ object.name }}{% endblock %}
+{% block title %}Editing: {{ object.title }}{% endblock %}
 
 {% block content %}
 <div class="admin-bar">
     <div class="admin-bar__inner">
-        <h2 class="heading heading--no-margin">Editing: {{ object.name }}</h2>
+        <h2 class="heading heading--no-margin">Editing: {{ object.title}}</h2>
     </div>
 </div>
 

--- a/opentech/apply/projects/templatetags/approval_tools.py
+++ b/opentech/apply/projects/templatetags/approval_tools.py
@@ -15,8 +15,4 @@ def user_can_approve_project(project, user):
 
 @register.simple_tag
 def user_can_edit_project(project, user):
-    if project.editable:
-        return True
-
-    # Approver can edit it when they are approving
-    return user.is_approver and project.can_make_approval
+    return project.editable_by(user)

--- a/opentech/apply/projects/templatetags/approval_tools.py
+++ b/opentech/apply/projects/templatetags/approval_tools.py
@@ -11,3 +11,12 @@ def user_has_approved(project, user):
 @register.simple_tag
 def user_can_approve_project(project, user):
     return user.is_approver and not user_has_approved(project, user)
+
+
+@register.simple_tag
+def user_can_edit_project(project, user):
+    if project.editable:
+        return True
+
+    # Approver can edit it when they are approving
+    return user.is_approver and project.can_make_approval

--- a/opentech/apply/projects/tests/factories.py
+++ b/opentech/apply/projects/tests/factories.py
@@ -5,9 +5,13 @@ import factory
 from django.utils import timezone
 
 from opentech.apply.funds.tests.factories import ApplicationSubmissionFactory
-from opentech.apply.projects.models import (DocumentCategory, PacketFile,
-                                            Project)
-from opentech.apply.users.tests.factories import UserFactory
+from opentech.apply.projects.models import (
+    DocumentCategory,
+    PacketFile,
+    Project,
+)
+from opentech.apply.users.tests.factories import StaffFactory, UserFactory
+
 
 ADDRESS = {
     'country': 'GB',
@@ -48,6 +52,7 @@ class ProjectFactory(factory.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
 
     title = factory.Sequence('name {}'.format)
+    lead = factory.SubFactory(StaffFactory)
     contact_legal_name = 'test'
     contact_email = 'test@example.com'
     contact_address = json.dumps(ADDRESS)
@@ -55,6 +60,8 @@ class ProjectFactory(factory.DjangoModelFactory):
     value = decimal.Decimal('100')
     proposed_start = factory.LazyFunction(timezone.now)
     proposed_end = factory.LazyFunction(timezone.now)
+
+    is_locked = False
 
     class Meta:
         model = Project

--- a/opentech/apply/projects/tests/test_forms.py
+++ b/opentech/apply/projects/tests/test_forms.py
@@ -1,10 +1,10 @@
 from django.test import TestCase
 
-from ..forms import ProjectEditForm
+from ..forms import ProjectApprovalForm
 from .factories import ProjectFactory, address_to_form_data
 
 
-class TestProjectEditForm(TestCase):
+class TestProjectApprovalForm(TestCase):
     def test_updating_fields_sets_changed_flag(self):
         project = ProjectFactory()
 
@@ -20,7 +20,7 @@ class TestProjectEditForm(TestCase):
             'proposed_end': project.proposed_end,
         }
         data.update(address_to_form_data())
-        form = ProjectEditForm(instance=project, data=data)
+        form = ProjectApprovalForm(instance=project, data=data)
         form.save()
 
         self.assertTrue(project.user_has_updated_details)

--- a/opentech/apply/projects/tests/test_views.py
+++ b/opentech/apply/projects/tests/test_views.py
@@ -13,7 +13,7 @@ from opentech.apply.users.tests.factories import (
 from opentech.apply.utils.testing.tests import BaseViewTestCase
 
 from ..forms import SetPendingForm
-from ..views import ProjectDetailView, ProjectEditView
+from ..views import ProjectDetailView
 from .factories import (
     DocumentCategoryFactory,
     PacketFileFactory,

--- a/opentech/apply/projects/views.py
+++ b/opentech/apply/projects/views.py
@@ -1,9 +1,11 @@
 from copy import copy
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic import CreateView, DetailView, FormView, UpdateView
 
 from opentech.apply.activity.messaging import MESSAGES, messenger
@@ -201,9 +203,11 @@ class ProjectApprovalEditView(UpdateView):
     model = Project
 
     def dispatch(self, request, *args, **kwargs):
-        if not self.object.editable_by(request.user):
+        project = self.get_object()
+        if not project.editable_by(request.user):
             messages.info(self.request, _('You are not allowed to edit the project at this time'))
-            return redirect(self.object)
+            return redirect(project)
+        return super().dispatch(request, *args, **kwargs)
 
 
 class ApplicantProjectEditView(UpdateView):
@@ -216,9 +220,9 @@ class ApplicantProjectEditView(UpdateView):
         if project.user != request.user:
             raise PermissionDenied
 
-        if not self.object.editable_by(request.user):
+        if not project.editable_by(request.user):
             messages.info(self.request, _('You are not allowed to edit the project at this time'))
-            return redirect(self.object)
+            return redirect(project)
 
         return super().dispatch(request, *args, **kwargs)
 

--- a/opentech/apply/projects/views.py
+++ b/opentech/apply/projects/views.py
@@ -1,5 +1,6 @@
 from copy import copy
 
+from django.contrib import messages
 from django.db import transaction
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
@@ -11,10 +12,17 @@ from opentech.apply.users.decorators import staff_required
 from opentech.apply.utils.views import (DelegateableView, DelegatedViewMixin,
                                         ViewDispatcher)
 
-from .forms import (CreateApprovalForm, ProjectEditForm, RejectionForm,
-                    RemoveDocumentForm, SetPendingForm, UpdateProjectLeadForm,
-                    UploadDocumentForm)
-from .models import CONTRACTING, Approval, PacketFile, Project
+from .forms import (
+    CreateApprovalForm,
+    ProjectApprovalForm,
+    ProjectEditForm,
+    RejectionForm,
+    RemoveDocumentForm,
+    SetPendingForm,
+    UpdateProjectLeadForm,
+    UploadDocumentForm,
+)
+from .models import CONTRACTING, Approval, DocumentCategory, Project, PacketFile
 
 
 @method_decorator(staff_required, name='dispatch')
@@ -167,8 +175,20 @@ class AdminProjectDetailView(ActivityContextMixin, DelegateableView, DetailView)
         return context
 
 
-class ApplicantProjectDetailView(DetailView):
+class ApplicantProjectDetailView(ActivityContextMixin, DelegateableView, DetailView):
+    form_views = [
+        CommentFormView,
+    ]
+
     model = Project
+    template_name_suffix = '_applicant_detail'
+
+    def dispatch(self, request, *args, **kwargs):
+        project = self.get_object()
+        # This view is only for applicants.
+        if project.user != request.user:
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
 
 
 class ProjectDetailView(ViewDispatcher):
@@ -176,7 +196,33 @@ class ProjectDetailView(ViewDispatcher):
     applicant_view = ApplicantProjectDetailView
 
 
-@method_decorator(staff_required, name='dispatch')
-class ProjectEditView(UpdateView):
+class ProjectApprovalEditView(UpdateView):
+    form_class = ProjectApprovalForm
+    model = Project
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self.object.editable_by(request.user):
+            messages.info(self.request, _('You are not allowed to edit the project at this time'))
+            return redirect(self.object)
+
+
+class ApplicantProjectEditView(UpdateView):
     form_class = ProjectEditForm
     model = Project
+
+    def dispatch(self, request, *args, **kwargs):
+        project = self.get_object()
+        # This view is only for applicants.
+        if project.user != request.user:
+            raise PermissionDenied
+
+        if not self.object.editable_by(request.user):
+            messages.info(self.request, _('You are not allowed to edit the project at this time'))
+            return redirect(self.object)
+
+        return super().dispatch(request, *args, **kwargs)
+
+
+class ProjectEditView(ViewDispatcher):
+    admin_view = ProjectApprovalEditView
+    applicant_view = ApplicantProjectEditView

--- a/opentech/apply/projects/views.py
+++ b/opentech/apply/projects/views.py
@@ -24,7 +24,7 @@ from .forms import (
     UpdateProjectLeadForm,
     UploadDocumentForm,
 )
-from .models import CONTRACTING, Approval, DocumentCategory, Project, PacketFile
+from .models import CONTRACTING, Approval, Project, PacketFile
 
 
 @method_decorator(staff_required, name='dispatch')

--- a/opentech/apply/users/tests/factories.py
+++ b/opentech/apply/users/tests/factories.py
@@ -3,7 +3,12 @@ from django.contrib.auth.models import Group
 
 import factory
 
-from ..groups import APPLICANT_GROUP_NAME, REVIEWER_GROUP_NAME, STAFF_GROUP_NAME
+from ..groups import (
+    APPLICANT_GROUP_NAME,
+    APPROVER_GROUP_NAME,
+    REVIEWER_GROUP_NAME,
+    STAFF_GROUP_NAME,
+)
 
 
 class GroupFactory(factory.DjangoModelFactory):
@@ -55,6 +60,16 @@ class StaffFactory(OAuthUserFactory):
     def groups(self, create, extracted, **kwargs):
         if create:
             self.groups.add(GroupFactory(name=STAFF_GROUP_NAME))
+
+
+class ApproverFactory(StaffFactory):
+    @factory.post_generation
+    def groups(self, create, extracted, **kwargs):
+        if create:
+            self.groups.add(
+                GroupFactory(name=STAFF_GROUP_NAME),
+                GroupFactory(name=APPROVER_GROUP_NAME),
+            )
 
 
 class SuperUserFactory(StaffFactory):


### PR DESCRIPTION
* Adds in the applicant view with basic information
* Split the edit form into PAF and project edit (for staff and applicant)
* Allows applicants to edit the form before approval
* Allow Approvers to edit the PAF before approving
* Adds tests for access to the edit form
* Improve formatting of text on the project detail page
* Make the emails to the applicants generic for the submission & project

