### PR TITLE
Fix sentry:OTF-WEBAPP-TEST-2G - projects of labs not rendering

### DIFF
--- a/opentech/apply/projects/templates/application_projects/project_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_detail.html
@@ -23,7 +23,7 @@
                 {% endif %}
             </span>
 
-            {% if request.user.is_apply_staff %}
+            {% if request.user.is_apply_staff and object.submission.round %}
             <span>
                 <a class="link--transparent link--underlined" href="{% url 'apply:rounds:detail' pk=object.submission.round.pk %}">{{ object.submission.round }}</a>
             </span>


### PR DESCRIPTION
Fixes a bug where the when there is no round on the submission (e.g. labs) the page fails to render. 

Also tests were not fully rendering the page, so rewrote to use the full request in order to get a working render. (could have done this on the class, but moved to be inline with other tests.