### PR TITLE
Add Debug Toolbar to Dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v2-python-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - v2-python-{{ .Branch }}-{{ checksum "requirements-dev.txt" }}
             - v2-python-{{ .Branch }}-
             - v2-python-
 
@@ -46,7 +46,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install coverage codecov
-            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
 
       - run:
           name: install node dependencies
@@ -57,7 +57,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v2-python-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: v2-python-{{ .Branch }}-{{ checksum "requirements-dev.txt" }}
 
       - save_cache:
           paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - pip install codecov
 
   # Install project dependencies
-  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
 
   # Install node
   - nvm install 10

--- a/opentech/settings/dev.py
+++ b/opentech/settings/dev.py
@@ -8,8 +8,6 @@ SECRET_KEY = 'CHANGEME!!!'
 
 WAGTAIL_CACHE = False
 
-INTERNAL_IPS = ('127.0.0.1', '10.0.2.2')
-
 ALLOWED_HOSTS = ['apply.localhost', 'localhost', '127.0.0.1', 'dev.otf.is', 'dev-apply.otf.is']
 
 BASE_URL = 'http://localhost:8000'
@@ -106,15 +104,42 @@ if LOCAL_FILE_LOGGING:
         }
     }
 
-# Set up the Django debug toolbar. See also root urls.py.
-if DEBUGTOOLBAR:
-    INSTALLED_APPS += [
+
+# Debug Toolbar
+# https://django-debug-toolbar.readthedocs.io/en/latest/index.html
+if DEBUG:
+    INSTALLED_APPS = [
+        *INSTALLED_APPS,
         'debug_toolbar',
     ]
-
     MIDDLEWARE = [
         'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ] + MIDDLEWARE
+        *MIDDLEWARE,
+    ]
+    # The 10.0.x address here allows vagrant users to use the debug toolbar
+    # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#configuring-internal-ips
+    INTERNAL_IPS = ['127.0.0.1', '10.0.2.2']
+
+# We disable all panels by default here since some of them (SQL, Template,
+# Profiling) can be very CPU intensive for this site.  However disabled panels
+# can be easily toggled on in the UI.
+DEBUG_TOOLBAR_CONFIG = {
+    "DISABLE_PANELS": {
+        'debug_toolbar.panels.versions.VersionsPanel',
+        'debug_toolbar.panels.settings.SettingsPanel',
+        'debug_toolbar.panels.headers.HeadersPanel',
+        'debug_toolbar.panels.request.RequestPanel',
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+        'debug_toolbar.panels.templates.TemplatesPanel',
+        'debug_toolbar.panels.cache.CachePanel',
+        'debug_toolbar.panels.signals.SignalsPanel',
+        'debug_toolbar.panels.logging.LoggingPanel',
+        'debug_toolbar.panels.redirects.RedirectsPanel',
+        'debug_toolbar.panels.profiling.ProfilingPanel',
+    },
+    "SHOW_COLLAPSED": True,
+}
 
 
 WEBPACK_LOADER['DEFAULT'].update({

--- a/opentech/settings/dev.py
+++ b/opentech/settings/dev.py
@@ -126,6 +126,7 @@ if DEBUG:
 DEBUG_TOOLBAR_CONFIG = {
     "DISABLE_PANELS": {
         'debug_toolbar.panels.versions.VersionsPanel',
+        'debug_toolbar.panels.timer.TimerPanel',
         'debug_toolbar.panels.settings.SettingsPanel',
         'debug_toolbar.panels.headers.HeadersPanel',
         'debug_toolbar.panels.request.RequestPanel',
@@ -140,7 +141,6 @@ DEBUG_TOOLBAR_CONFIG = {
     },
     "SHOW_COLLAPSED": True,
 }
-
 
 WEBPACK_LOADER['DEFAULT'].update({
     'STATS_FILE': os.path.join(BASE_DIR, './opentech/static_compiled/app/webpack-stats.json'),

--- a/opentech/settings/local.py.example
+++ b/opentech/settings/local.py.example
@@ -7,22 +7,25 @@ CACHES = {
     }
 }
 
+# ALLOWED_HOSTS = ['apply.otf.test', 'otf.test', 'apply.hypha.test', 'hypha.test', '127.0.0.1']
+
+# BASE_URL = 'http://otf.test'
+
+# Turn off DEBUG mode.
+# DEBUG = False
+
 # Write log to local file.
 # LOCAL_FILE_LOGGING = True
 
 # Write e-mails to local files.
 # LOCAL_FILE_EMAIL = True
 
-# On staging, uncomment the following to enable the styleguide
+# Enable the styleguide.
 # ENABLE_STYLEGUIDE = True
-
-# ALLOWED_HOSTS = ['apply.otf.test', 'otf.test', '127.0.0.1']
-
-# BASE_URL = 'http://otf.test'
 
 # SECRET_KEY = 'CHANGEME!!!'
 
-# Enable Wagtail Cache while developing
+# Enable Wagtail Cache.
 # WAGTAIL_CACHE = True
 
 # If you have a problem with "CSRF cookie not set".

--- a/opentech/settings/local.py.example
+++ b/opentech/settings/local.py.example
@@ -7,10 +7,6 @@ CACHES = {
     }
 }
 
-# Use the Django debug toolbar. First install via pip.
-# pip install django-debug-toolbar
-# DEBUGTOOLBAR = True
-
 # Write log to local file.
 # LOCAL_FILE_LOGGING = True
 

--- a/opentech/urls.py
+++ b/opentech/urls.py
@@ -65,7 +65,7 @@ urlpatterns += [
 ]
 
 
-if settings.DEBUG and settings.DEBUGTOOLBAR:
+if settings.DEBUG:
     import debug_toolbar
     urlpatterns = [
         path('__debug__/', include(debug_toolbar.urls)),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+django-debug-toolbar==2.0
 factory_boy==2.9.2
 Faker==1.0.8  # Pinning to avoid API changes to pydecimal in 0.x - could go higher in future
 flake8==3.7.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+-r requirements.txt
+
+factory_boy==2.9.2
+Faker==1.0.8  # Pinning to avoid API changes to pydecimal in 0.x - could go higher in future
+flake8==3.7.9
+responses==0.10.6
+stellar==0.4.5
+wagtail-factories==1.1.0
+Werkzeug==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,3 @@
-# Development dependencies, install manually if needed.
-# stellar==0.4.5
-# Werkzeug==0.14.1
-
-# Test dependencies
-flake8
-factory_boy==2.9.2
-Faker==1.0.8 # Pinning to avoid API changes to pydecimal in 0.x - could go higher in future
-wagtail-factories==1.1.0
-responses==0.10.6
-
 # Monitor dependencies
 scout-apm==2.5.0
 sentry-sdk==0.12.3

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -32,7 +32,7 @@ su - vagrant -c "$PIP install --upgrade pip"
 su - vagrant -c "$PIP install --upgrade six setuptools"
 
 # Install PIP requirements
-su - vagrant -c "$PIP install -r $PROJECT_DIR/requirements.txt"
+su - vagrant -c "$PIP install -r $PROJECT_DIR/requirements-dev.txt"
 
 
 # Set execute permissions on manage.py as they get lost if we build from a zip file


### PR DESCRIPTION
This sets up development dependencies so we're not installing testing libraries into production environments and installs the Django Debug Toolbar in development, configuring it so it's always running but with its panels disabled.  I've disabled the panels to cope with the prohibitive performance penalty some of the panels bring, but they can be toggled on in the UI easily.