### PR TITLE
Bugfix/ensure projects disbaled works correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
           PGUSER: root
           DJANGO_SETTINGS_MODULE: opentech.settings.test
           SEND_MESSAGES: false
-          PROJECTS_ENABLED: true
 
       - image: circleci/postgres:10.5
         environment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
   global:
     - DJANGO_SETTINGS_MODULE=opentech.settings.test
     - DATABASE_URL=postgres://postgres@localhost/test_db
-    - PROJECTS_ENABLED=true
 
 before_script:
   # Create a database

--- a/opentech/apply/determinations/tests/test_views.py
+++ b/opentech/apply/determinations/tests/test_views.py
@@ -2,7 +2,7 @@ import urllib
 
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.test import RequestFactory
+from django.test import override_settings, RequestFactory
 from django.urls import reverse_lazy
 
 from opentech.apply.activity.models import Activity
@@ -88,7 +88,15 @@ class DeterminationFormTestCase(BaseViewTestCase):
         response = self.get_page(submission, 'form')
         self.assertNotContains(response, 'Update ')
 
+    @override_settings(PROJECTS_ENABLED=False)
     def test_can_edit_draft_determination_if_not_lead(self):
+        submission = ApplicationSubmissionFactory(status='in_discussion')
+        determination = DeterminationFactory(submission=submission, author=self.user, accepted=True)
+        response = self.post_page(submission, {'data': 'value', 'outcome': determination.outcome}, 'form')
+        self.assertContains(response, 'Approved')
+        self.assertRedirects(response, self.absolute_url(submission.get_absolute_url()))
+
+    def test_can_edit_draft_determination_if_not_lead_with_projects(self):
         submission = ApplicationSubmissionFactory(status='in_discussion')
         determination = DeterminationFactory(submission=submission, author=self.user, accepted=True)
         response = self.post_page(submission, {'data': 'value', 'outcome': determination.outcome}, 'form')

--- a/opentech/apply/determinations/views.py
+++ b/opentech/apply/determinations/views.py
@@ -267,13 +267,14 @@ class DeterminationCreateOrUpdateView(CreateOrUpdateView):
 
             if self.submission.accepted_for_funding:
                 project = Project.create_from_submission(self.submission)
-                messenger(
-                    MESSAGES.CREATED_PROJECT,
-                    request=self.request,
-                    user=self.request.user,
-                    source=project,
-                    related=project.submission,
-                )
+                if project:
+                    messenger(
+                        MESSAGES.CREATED_PROJECT,
+                        request=self.request,
+                        user=self.request.user,
+                        source=project,
+                        related=project.submission,
+                    )
 
         messenger(
             MESSAGES.DETERMINATION_OUTCOME,

--- a/opentech/settings/test.py
+++ b/opentech/settings/test.py
@@ -8,6 +8,8 @@ from .base import *  # noqa
 
 SECRET_KEY = 'NOT A SECRET'
 
+PROJECTS_ENABLED = True
+
 # Need this to ensure white noise doesn't kill the speed of testing
 # http://whitenoise.evans.io/en/latest/django.html#whitenoise-makes-my-tests-run-slow
 WHITENOISE_AUTOREFRESH = True


### PR DESCRIPTION
I've moved the `PROJECTS_ENABLED` flag into `settings/test.py` which is more consistent with the way the codebase currently manages settings. (this was also tripping me up locally and a pain to debug)

However in not having the setting configured i noticed that one of the tests for failing correctly, have added a duplicate of the test case with projects disabled to ensure that determinations can still be sent.