### PR TITLE
Feature/performance audit

### DIFF
--- a/opentech/apply/activity/templatetags/activity_tags.py
+++ b/opentech/apply/activity/templatetags/activity_tags.py
@@ -12,7 +12,7 @@ register = template.Library()
 
 @register.filter
 def display_author(activity, user):
-    if activity.source.user == user and isinstance(activity.related_object, Review):
+    if isinstance(activity.related_object, Review) and activity.source.user == user:
         return 'Reviewer'
     return activity.user
 

--- a/opentech/apply/activity/views.py
+++ b/opentech/apply/activity/views.py
@@ -15,16 +15,19 @@ class AllActivityContextMixin:
     def get_context_data(self, **kwargs):
         extra = {
             'actions': Activity.actions.select_related(
-                'source_content_type',
                 'user',
+            ).prefetch_related(
+                'source',
             )[:ACTIVITY_LIMIT],
             'comments': Activity.comments.select_related(
-                'source_content_type',
                 'user',
+            ).prefetch_related(
+                'source',
             )[:ACTIVITY_LIMIT],
             'all_activity': Activity.objects.select_related(
-                'source_content_type',
                 'user',
+            ).prefetch_related(
+                'source',
             )[:ACTIVITY_LIMIT],
         }
         return super().get_context_data(**extra, **kwargs)

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -200,8 +200,10 @@ class ApplicationSubmissionQueryset(JSONOrderable):
         ).prefetch_related(
             Prefetch(
                 'assigned',
-                queryset=AssignedReviewers.objects.reviewed().review_order().prefetch_related(
-                    Prefetch('opinions', queryset=ReviewOpinion.objects.select_related('author__reviewer'))
+                queryset=AssignedReviewers.objects.reviewed().review_order().select_related(
+                    'reviewer',
+                ).prefetch_related(
+                    Prefetch('review__opinions', queryset=ReviewOpinion.objects.select_related('author')),
                 ),
                 to_attr='has_reviewed'
             ),
@@ -210,7 +212,6 @@ class ApplicationSubmissionQueryset(JSONOrderable):
                 queryset=AssignedReviewers.objects.not_reviewed().staff(),
                 to_attr='hasnt_reviewed'
             )
-
         ).select_related(
             'page',
             'round',
@@ -218,6 +219,7 @@ class ApplicationSubmissionQueryset(JSONOrderable):
             'user',
             'previous__page',
             'previous__round',
+            'previous__lead',
         )
 
 

--- a/opentech/apply/funds/templates/funds/submissions.html
+++ b/opentech/apply/funds/templates/funds/submissions.html
@@ -14,11 +14,6 @@
 </div>
 
 <div class="wrapper wrapper--large wrapper--inner-space-medium">
-
-    {% if closed_rounds or open_rounds %}
-        {% include "funds/includes/round-block.html" with closed_rounds=closed_rounds open_rounds=open_rounds title=rounds_title %}
-    {% endif %}
-
     {% block table %}
         {{ block.super }}
     {% endblock %}

--- a/opentech/apply/utils/image.py
+++ b/opentech/apply/utils/image.py
@@ -1,12 +1,22 @@
+from django.core.cache import cache
 from django.urls import reverse
 from django.utils.html import format_html
 
 
+def image_url_cache_key(image_id, spec):
+    return f'image_url_cache_{image_id}_{spec}'
+
+
 def generate_image_url(image, filter_spec):
+    cache_key = image_url_cache_key(image.id, filter_spec)
+    url = cache.get(cache_key)
+    if url:
+        return url
     from wagtail.images.views.serve import generate_signature
     signature = generate_signature(image.id, filter_spec)
     url = reverse('wagtailimages_serve', args=(signature, image.id, filter_spec))
     url += image.file.name[len('original_images/'):]
+    cache.set(cache_key, url)
     return url
 
 


### PR DESCRIPTION
Pages with activities and submissions had slowed down (~1000 queries and we were hitting the PSQL page buffer size :boom: )

Turns out i was a little overzealous with my refactor of the deserialisation method - comment added to prevent future me doing the same thing again.

Also made a few more tweaks to generally improve the performance on the listing pages:
* Tweaked prefetching to fetch the correct things
* Tweaked logic order to avoid DB lookup unless nessecary
* Removed unused template include that seemed to be firing of a DB request
* Cache the URL for the reviewer icons as this is a very repetitive lookup that can be cached.

Now down to ~80 queries for a standard page with listings and some n+1 exist, but generally much more stable and manageable.