### PR TITLE
Add Projects table to Staff dashboard

### DIFF
--- a/opentech/apply/dashboard/templates/dashboard/dashboard.html
+++ b/opentech/apply/dashboard/templates/dashboard/dashboard.html
@@ -66,6 +66,14 @@
             {% endif %}
         </div>
     {% endif %}
+
+    {% if projects %}
+    <div class="wrapper wrapper--bottom-space">
+        <h4 class="heading heading--normal heading--no-margin">Your projects</h4>
+        {% render_table projects %}
+    </div>
+    {% endif %}
+
 </div>
 {% endblock %}
 

--- a/opentech/apply/projects/tables.py
+++ b/opentech/apply/projects/tables.py
@@ -1,0 +1,25 @@
+import textwrap
+
+import django_tables2 as tables
+
+from .models import Project
+
+
+class ProjectsDashboardTable(tables.Table):
+    title = tables.LinkColumn(
+        'funds:projects:detail',
+        text=lambda r: textwrap.shorten(r.title, width=30, placeholder="..."),
+        args=[tables.utils.A('pk')],
+    )
+    status = tables.Column(verbose_name='Status', accessor='status')
+    fund = tables.Column(verbose_name='Fund', accessor='submission.page')
+    end_date = tables.DateColumn(verbose_name='End Date', accessor='proposed_end')
+    fund_allocation = tables.Column(verbose_name='Fund Allocation', accessor='value')
+
+    class Meta:
+        fields = ['title', 'status', 'fund', 'end_date', 'fund_allocation']
+        model = Project
+        # orderable = False
+
+    def render_fund_allocation(self, value):
+        return f'${value}'


### PR DESCRIPTION
This adds a Projects table to the main admin Dashboard.

I've left the table unorderable since setting GET args on `AdminDashboardView` redirects off to another view currently.  Once [this](https://github.com/OpenTechFund/opentech.fund/issues/1340#issuecomment-522523638) is answered we can make a call on what to do.