### PR TITLE
Automatic Project Creation Feature Flag

### DIFF
--- a/opentech/apply/determinations/tests/test_views.py
+++ b/opentech/apply/determinations/tests/test_views.py
@@ -270,6 +270,48 @@ class DeterminationFormTestCase(BaseViewTestCase):
         self.assertIsNone(submission_next)
         self.assertFalse(hasattr(submission_original, 'project'))
 
+    @override_settings(PROJECTS_AUTO_CREATE=False)
+    def test_disabling_project_auto_creation_stops_projects_being_created(self):
+        submission = ApplicationSubmissionFactory(
+            status='post_review_discussion',
+            workflow_stages=1,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': ACCEPTED,
+            'message': 'You are invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+
+        self.assertIsNone(submission_next)
+        self.assertFalse(hasattr(submission_original, 'project'))
+
+    @override_settings(PROJECTS_ENABLED=False, PROJECTS_AUTO_CREATE=True)
+    def test_disabling_projects_ignores_auto_creation_setting(self):
+        submission = ApplicationSubmissionFactory(
+            status='post_review_discussion',
+            workflow_stages=1,
+            lead=self.user,
+        )
+
+        self.post_page(submission, {
+            'data': 'value',
+            'outcome': ACCEPTED,
+            'message': 'You are invited to submit a proposal',
+        }, 'form')
+
+        # Cant use refresh from DB with FSM
+        submission_original = self.refresh(submission)
+        submission_next = submission_original.next
+
+        self.assertIsNone(submission_next)
+        self.assertFalse(hasattr(submission_original, 'project'))
+
 
 class BatchDeterminationTestCase(BaseViewTestCase):
     user_factory = StaffFactory

--- a/opentech/apply/determinations/views.py
+++ b/opentech/apply/determinations/views.py
@@ -1,5 +1,6 @@
 from urllib import parse
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
@@ -275,7 +276,7 @@ class DeterminationCreateOrUpdateView(CreateOrUpdateView):
                 proposal_form=proposal_form,
             )
 
-            if self.submission.accepted_for_funding:
+            if self.submission.accepted_for_funding and settings.PROJECTS_AUTO_CREATE:
                 project = Project.create_from_submission(self.submission)
                 if project:
                     messenger(

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -627,3 +627,7 @@ REST_FRAMEWORK = {
 PROJECTS_ENABLED = False
 if env.get('PROJECTS_ENABLED', 'false').lower().strip() == 'true':
     PROJECTS_ENABLED = True
+
+PROJECTS_AUTO_CREATE = False
+if env.get('PROJECTS_AUTO_CREATE', 'false').lower().strip() == 'true':
+    PROJECTS_AUTO_CREATE = True

--- a/opentech/settings/dev.py
+++ b/opentech/settings/dev.py
@@ -35,6 +35,7 @@ except ImportError:
     pass
 
 PROJECTS_ENABLED = True
+PROJECTS_AUTO_CREATE = True
 
 # We add these here so they can react on settings made in local.py.
 

--- a/opentech/settings/test.py
+++ b/opentech/settings/test.py
@@ -9,6 +9,7 @@ from .base import *  # noqa
 SECRET_KEY = 'NOT A SECRET'
 
 PROJECTS_ENABLED = True
+PROJECTS_AUTO_CREATE = True
 
 # Need this to ensure white noise doesn't kill the speed of testing
 # http://whitenoise.evans.io/en/latest/django.html#whitenoise-makes-my-tests-run-slow


### PR DESCRIPTION
This adds the `PROJECT_AUTO_CREATE` settings flag and uses it to enable/disable the automated creation of projects when a Submission is given an accepted determination.  The existing `PROJECTS_ENABLED` flag will still disable Project creation and general Project features regardless of `PROJECT_AUTO_CREATE`'s value.