### PR TITLE
Set COOKIE_SECURE to true in env var to set session and CSRF cookies …

### DIFF
--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -596,6 +596,10 @@ if env.get('SECURE_BROWSER_XSS_FILTER', 'true').lower().strip() == 'true':
 if env.get('SECURE_CONTENT_TYPE_NOSNIFF', 'true').lower().strip() == 'true':
     SECURE_CONTENT_TYPE_NOSNIFF = True
 
+if env.get('COOKIE_SECURE', 'false').lower().strip() == 'true':
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+
 
 # Referrer-policy header settings
 # https://django-referrer-policy.readthedocs.io/en/1.0/

--- a/opentech/settings/local.py.example
+++ b/opentech/settings/local.py.example
@@ -25,3 +25,7 @@ CACHES = {
 
 # Enable Wagtail Cache while developing
 # WAGTAIL_CACHE = True
+
+# If you have a problem with "CSRF cookie not set".
+# CSRF_COOKIE_SAMESITE = None
+# SESSION_COOKIE_SAMESITE = None


### PR DESCRIPTION
…to secure, only passed over https. Also added CSRF_COOKIE_SAMESITE example to local.py.example