### PR TITLE
Feature/sprint 3 ux review

### DIFF
--- a/opentech/apply/categories/blocks.py
+++ b/opentech/apply/categories/blocks.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, SimpleLazyObject
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.core.blocks import BooleanBlock, CharBlock, ChooserBlock, TextBlock
@@ -19,6 +19,10 @@ class ModelChooserBlock(ChooserBlock):
     @cached_property
     def target_model(self):
         return resolve_model_string(self._target_model)
+
+    def to_python(self, value):
+        super_method = super().to_python
+        return SimpleLazyObject(lambda: super_method(value))
 
 
 class CategoryQuestionBlock(OptionalFormFieldBlock):

--- a/opentech/apply/funds/paginators.py
+++ b/opentech/apply/funds/paginators.py
@@ -1,0 +1,113 @@
+from django.core.paginator import EmptyPage, Page, PageNotAnInteger, Paginator
+from django.utils.translation import gettext as _
+
+# https://django-tables2.readthedocs.io/en/latest/pages/api-reference.html#django_tables2.paginators.LazyPaginator
+
+# REMOVE IN django_tables2 2.0
+
+
+class LazyPaginator(Paginator):
+    """
+    Implement lazy pagination, preventing any count() queries.
+
+    By default, for any valid page, the total number of pages for the paginator will be
+
+     - `current + 1` if the number of records fetched for the current page offset is
+       bigger than the number of records per page.
+     - `current` if the number of records fetched is less than the number of records per page.
+
+    The number of additional records fetched can be adjusted using `look_ahead`, which
+    defaults to 1 page. If you like to provide a little more extra information on how much
+    pages follow the current page, you can use a higher value.
+
+    .. note::
+
+        The number of records fetched for each page is `per_page * look_ahead + 1`, so increasing
+        the value for `look_ahead` makes the view a bit more expensive.
+
+    So::
+
+        paginator = LazyPaginator(range(10000), 10)
+
+        >>> paginator.page(1).object_list
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        >>> paginator.num_pages
+        2
+        >>> paginator.page(10).object_list
+        [91, 92, 93, 94, 95, 96, 97, 98, 99, 100]
+        >>> paginator.num_pages
+        11
+        >>> paginator.page(1000).object_list
+        [9991, 9992, 9993, 9994, 9995, 9996, 9997, 9998, 9999]
+        >>> paginator.num_pages
+        1000
+
+    Usage with `~.SingleTableView`::
+
+        class UserListView(SingleTableView):
+            table_class = UserTable
+            table_data = User.objects.all()
+            pagination_class = LazyPaginator
+
+    Or with `~.RequestConfig`::
+
+        RequestConfig(paginate={"paginator_class": LazyPaginator}).configure(table)
+
+    .. versionadded :: 2.0.0
+    """
+
+    look_ahead = 1
+
+    def __init__(self, object_list, per_page, look_ahead=None, **kwargs):
+        self._num_pages = None
+        if look_ahead is not None:
+            self.look_ahead = look_ahead
+
+        super().__init__(object_list, per_page, **kwargs)
+
+    def validate_number(self, number):
+        """Validate the given 1-based page number."""
+        try:
+            if isinstance(number, float) and not number.is_integer():
+                raise ValueError
+            number = int(number)
+        except (TypeError, ValueError):
+            raise PageNotAnInteger(_("That page number is not an integer"))
+        if number < 1:
+            raise EmptyPage(_("That page number is less than 1"))
+        return number
+
+    def page(self, number):
+        number = self.validate_number(number)
+        bottom = (number - 1) * self.per_page
+        top = bottom + self.per_page
+        # Retrieve more objects to check if there is a next page.
+        look_ahead_items = (self.look_ahead - 1) * self.per_page + 1
+        objects = list(self.object_list[bottom: top + self.orphans + look_ahead_items])
+        objects_count = len(objects)
+        if objects_count > (self.per_page + self.orphans):
+            # If another page is found, increase the total number of pages.
+            self._num_pages = number + (objects_count // self.per_page)
+            # In any case,  return only objects for this page.
+            objects = objects[: self.per_page]
+        elif (number != 1) and (objects_count <= self.orphans):
+            raise EmptyPage(_("That page contains no results"))
+        else:
+            # This is the last page.
+            self._num_pages = number
+        return Page(objects, number, self)
+
+    def _get_count(self):
+        return 0
+
+    count = property(_get_count)
+
+    def _get_num_pages(self):
+        return self._num_pages
+
+    num_pages = property(_get_num_pages)
+
+    def _get_page_range(self):
+        raise NotImplementedError
+
+    page_range = property(_get_page_range)

--- a/opentech/apply/funds/templates/funds/includes/actions.html
+++ b/opentech/apply/funds/templates/funds/includes/actions.html
@@ -2,12 +2,14 @@
 
 
 {% if PROJECTS_ENABLED %}
-<a data-fancybox
-    data-src="#create-project"
-    class="button button--bottom-space button--primary button--full-width {% if object.accepted_for_funding and not object.project %}is-not-disabled{% else %}is-disabled{% endif %}"
-    href="#">
-    Create Project
-</a>
+{% if object.accepted_for_funding and not object.project %}
+    <a data-fancybox
+        data-src="#create-project"
+        class="button button--bottom-space button--primary button--full-width"
+        href="#">
+        Create Project
+    </a>
+{% endif %}
 {% endif %}
 
 <a data-fancybox data-src="#screen-application" class="button button--bottom-space button--primary button--full-width {% if screening_form.should_show %}is-not-disabled{% else %}is-disabled{% endif %}" href="#">Screen application</a>

--- a/opentech/apply/funds/templates/funds/includes/create_project_form.html
+++ b/opentech/apply/funds/templates/funds/includes/create_project_form.html
@@ -1,4 +1,6 @@
 <div class="modal" id="create-project">
     <h4 class="modal__header-bar">Create Project</h4>
-    {% include 'funds/includes/delegated_form_base.html' with form=project_form value='Create'%}
+    <p>This will create a new project and notify the Applicant.</p>
+    <p>This cannot be undone.</p>
+    {% include 'funds/includes/delegated_form_base.html' with form=project_form value='Confirm'%}
 </div>

--- a/opentech/apply/funds/templates/funds/tables/table.html
+++ b/opentech/apply/funds/templates/funds/tables/table.html
@@ -1,5 +1,5 @@
 {% extends 'django_tables2/table.html' %}
-{% load django_tables2 table_tags review_tags wagtailimages_tags %}
+{% load django_tables2 table_tags review_tags wagtailimages_tags i18n %}
 
 {% block table.tbody.row %}
     <tr {{ row.attrs.as_html }}>
@@ -118,3 +118,31 @@
 {% block table.tbody.empty_text %}
 <tr class="all-submissions-table__empty"><td colspan="{{ table.columns|length }}">{{ table.empty_text }}</td></tr>
 {% endblock table.tbody.empty_text %}
+
+{% block pagination %}
+    {% if table.page and table.paginator.num_pages > 1 %}
+    <ul class="pagination">
+        {% if table.page.has_previous %}
+            <li class="previous">
+                <a href="{% querystring table.prefixed_page_field=table.page.previous_page_number %}">
+                    {% trans 'previous' %}
+                </a>
+            </li>
+        {% endif %}
+        {% if table.page.has_previous or table.page.has_next %}
+            <li class="cardinality">
+                <p>
+                    Page {{ table.page.number }}
+                </p>
+            </li>
+        {% endif %}
+        {% if table.page.has_next %}
+            <li class="next">
+                <a href="{% querystring table.prefixed_page_field=table.page.next_page_number %}">
+                    {% trans 'next' %}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+    {% endif %}
+{% endblock pagination %}

--- a/opentech/apply/funds/views.py
+++ b/opentech/apply/funds/views.py
@@ -53,6 +53,7 @@ from .models import (
     RoundBase,
     LabBase
 )
+from .paginators import LazyPaginator
 from .permissions import is_user_has_access_to_view_submission
 from .tables import (
     AdminSubmissionsTable,
@@ -70,6 +71,7 @@ class BaseAdminSubmissionsTable(SingleTableMixin, FilterView):
     table_class = AdminSubmissionsTable
     filterset_class = SubmissionFilterAndSearch
     filter_action = ''
+    table_pagination = {'klass': LazyPaginator}
 
     excluded_fields = []
 

--- a/opentech/apply/projects/filters.py
+++ b/opentech/apply/projects/filters.py
@@ -15,20 +15,21 @@ from .models import (
     Project
 )
 
-
-class PaymentRequestListFilter(filters.FilterSet):
-    fund = Select2ModelMultipleChoiceFilter(label='Funds', queryset=get_used_funds)
-    project = Select2ModelMultipleChoiceFilter(label='Project', queryset=Project.objects.all())
-    status = Select2MultipleChoiceFilter(label='Status', choices=REQUEST_STATUS_CHOICES)
-
-    class Meta:
-        fields = ['project', 'status', 'fund']
-        model = PaymentRequest
+User = get_user_model()
 
 
 def get_project_leads(request):
-    User = get_user_model()
     return User.objects.filter(lead_projects__isnull=False).distinct()
+
+
+class PaymentRequestListFilter(filters.FilterSet):
+    fund = Select2ModelMultipleChoiceFilter(label='Funds', queryset=get_used_funds, field_name='project__submission__page')
+    status = Select2MultipleChoiceFilter(label='Status', choices=REQUEST_STATUS_CHOICES)
+    lead = Select2ModelMultipleChoiceFilter(label='Lead', queryset=get_project_leads, field_name='project__lead')
+
+    class Meta:
+        fields = ['lead', 'fund', 'status']
+        model = PaymentRequest
 
 
 class ProjectListFilter(filters.FilterSet):

--- a/opentech/apply/projects/forms.py
+++ b/opentech/apply/projects/forms.py
@@ -276,11 +276,11 @@ class EditPaymentRequestForm(forms.ModelForm):
 
 
 class SelectDocumentForm(forms.ModelForm):
-    document = forms.ChoiceField()
+    from_submission = forms.ChoiceField(label="Document")
 
     class Meta:
         model = PacketFile
-        fields = ['category', 'document']
+        fields = ['category', 'from_submission']
 
     def __init__(self, existing_files, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -289,10 +289,10 @@ class SelectDocumentForm(forms.ModelForm):
 
         choices = [(f.url, f.filename) for f in self.files]
 
-        self.fields['document'].choices = choices
+        self.fields['from_submission'].choices = choices
 
-    def clean_document(self):
-        file_url = self.cleaned_data['document']
+    def clean_from_submission(self):
+        file_url = self.cleaned_data['from_submission']
         for file in self.files:
             if file.url == file_url:
                 new_file = ContentFile(file.read())
@@ -345,6 +345,9 @@ class UploadDocumentForm(forms.ModelForm):
         fields = ['title', 'category', 'document']
         model = PacketFile
         widgets = {'title': forms.TextInput()}
+        labels = {
+            "title": "File Name",
+        }
 
     def __init__(self, user=None, instance=None, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/opentech/apply/projects/forms.py
+++ b/opentech/apply/projects/forms.py
@@ -276,11 +276,14 @@ class EditPaymentRequestForm(forms.ModelForm):
 
 
 class SelectDocumentForm(forms.ModelForm):
-    from_submission = forms.ChoiceField(label="Document")
+    document = forms.ChoiceField(
+        label="Document",
+        widget=forms.Select(attrs={'id': 'from_submission'})
+    )
 
     class Meta:
         model = PacketFile
-        fields = ['category', 'from_submission']
+        fields = ['category', 'document']
 
     def __init__(self, existing_files, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -289,10 +292,10 @@ class SelectDocumentForm(forms.ModelForm):
 
         choices = [(f.url, f.filename) for f in self.files]
 
-        self.fields['from_submission'].choices = choices
+        self.fields['document'].choices = choices
 
-    def clean_from_submission(self):
-        file_url = self.cleaned_data['from_submission']
+    def clean_document(self):
+        file_url = self.cleaned_data['document']
         for file in self.files:
             if file.url == file_url:
                 new_file = ContentFile(file.read())

--- a/opentech/apply/projects/tables.py
+++ b/opentech/apply/projects/tables.py
@@ -13,41 +13,47 @@ class BasePaymentRequestsTable(tables.Table):
         text=lambda r: textwrap.shorten(r.project.title, width=30, placeholder="..."),
         args=[tables.utils.A('pk')],
     )
-    fund = tables.Column(verbose_name='Fund', accessor='project.submission.page')
     status = tables.Column()
-    date_from = tables.DateColumn(verbose_name='Start Date')
-    date_to = tables.DateColumn(verbose_name='End Date')
+    requested_at = tables.DateColumn(verbose_name='Submitted')
 
     def render_value(self, value):
         return f'${value}'
 
 
 class PaymentRequestsDashboardTable(BasePaymentRequestsTable):
+    date_from = tables.DateColumn(verbose_name='Period Start')
+    date_to = tables.DateColumn(verbose_name='Period End')
+
     class Meta:
         fields = [
             'project',
-            'fund',
             'status',
+            'requested_at',
             'date_from',
             'date_to',
             'value',
         ]
         model = PaymentRequest
         orderable = False
+        order_by = ['-requested_at']
 
 
 class PaymentRequestsListTable(BasePaymentRequestsTable):
+    fund = tables.Column(verbose_name="Fund", accessor='project.submission.page')
+    lead = tables.Column(verbose_name="Lead", accessor='project.lead')
+
     class Meta:
         fields = [
             'project',
             'fund',
+            'lead',
             'status',
-            'date_from',
-            'date_to',
+            'requested_at',
             'value',
         ]
         model = PaymentRequest
         orderable = True
+        order_by = ['-requested_at']
 
     def order_value(self, qs, is_descending):
         direction = '-' if is_descending else ''

--- a/opentech/apply/projects/templates/application_projects/includes/payment_requests.html
+++ b/opentech/apply/projects/templates/application_projects/includes/payment_requests.html
@@ -50,7 +50,7 @@
             </tr>
             {% empty %}
             <tr>
-                No active Payment Requests.
+                <td colspan="5">No active Payment Requests.</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/opentech/apply/projects/templates/application_projects/payment_request_list.html
+++ b/opentech/apply/projects/templates/application_projects/payment_request_list.html
@@ -18,7 +18,7 @@
 
 <div class="wrapper wrapper--large wrapper--inner-space-medium">
     {% if table %}
-    {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=True %}
+    {% include "funds/includes/table_filter_and_search.html" with filter_form=filter_form search_term=search_term use_search=True filter_action=filter_action use_batch_actions=True search_placeholder="payment requests" %}
     {% render_table table %}
     {% else %}
     <p>No Requests Available</p>

--- a/opentech/apply/projects/templates/application_projects/project_admin_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_admin_detail.html
@@ -99,13 +99,6 @@
   Lead
 </a>
 
-<!-- <a data-fancybox -->
-<!-- data-src="#update-meta-categories" -->
-<!-- class="button button--bottom-space button--white button--full-width" -->
-<!-- href="#"> -->
-<!-- Meta Categories -->
-<!-- </a> -->
-
 {% endblock %}
 
 {% block project_approvals %}

--- a/opentech/apply/projects/templates/application_projects/project_admin_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_admin_detail.html
@@ -30,6 +30,8 @@
 
 <div class="modal" id="approve">
     <h4 class="modal__header-bar">Add Approval</h4>
+    <p>This will move the project into contracting and notify the compliance team.</p>
+    <p>This cannot be undone</p>
     {% include 'funds/includes/delegated_form_base.html' with form=add_approval_form value='Approve'%}
 </div>
 
@@ -41,7 +43,9 @@
 {% if contract_to_approve %}
 <div class="modal" id="approve-contract">
     <h4 class="modal__header-bar">Approve Contract</h4>
-    {% include 'funds/includes/delegated_form_base.html' with form=approve_contract_form value='Approve' %}
+    <p>You confirm that the uploaded contract is acceptable for commencing the project.</p>
+    <p>This cannot be undone.</p>
+    {% include 'funds/includes/delegated_form_base.html' with form=approve_contract_form value='Confirm' %}
 </div>
 {% endif %}
 

--- a/opentech/apply/projects/templates/application_projects/project_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_detail.html
@@ -128,7 +128,6 @@
                 <div class="wrapper wrapper--outer-space-large">
                     {% include "application_projects/includes/funding_block.html" %}
                     {% include "application_projects/includes/payment_requests.html" %}
-                    {% include "application_projects/includes/invoice_block.html" %}
                 </div>
                 {% endif %}
 
@@ -241,15 +240,6 @@
                     {% endfor %}
                 </div>
                 {% endif %}
-
-                <div class="sidebar__inner">
-                    <h5>Meta Categories</h5>
-
-                    <p>Meta Category</p>
-                    <p>Meta Category</p>
-                    <p>Meta Category</p>
-                </div>
-
             </aside>
         </div>
     </div>

--- a/opentech/apply/projects/templates/application_projects/project_detail.html
+++ b/opentech/apply/projects/templates/application_projects/project_detail.html
@@ -153,7 +153,11 @@
                     {% user_can_upload_contract object request.user as can_upload_contract %}
                     {% if can_upload_contract %}
                     <div class="modal" id="upload-contract">
-                        <h4 class="modal__header-bar">Upload Contract</h4>
+                        {% if not user.is_staff %}
+                            <h4 class="modal__header-bar">Upload Signed Contract</h4>
+                        {% else %}
+                            <h4 class="modal__header-bar">Upload Contract</h4>
+                        {% endif %}
                         {% include 'funds/includes/delegated_form_base.html' with form=contract_form value='Upload'%}
                     </div>
 

--- a/opentech/apply/projects/tests/test_views.py
+++ b/opentech/apply/projects/tests/test_views.py
@@ -37,6 +37,35 @@ from .factories import (
 )
 
 
+class TestUpdateLeadView(BaseViewTestCase):
+    base_view_name = 'detail'
+    url_name = 'funds:projects:{}'
+    user_factory = ApproverFactory
+
+    def get_kwargs(self, instance):
+        return {'pk': instance.id}
+
+    def test_update_lead(self):
+        project = ProjectFactory()
+
+        new_lead = self.user_factory()
+        response = self.post_page(project, {'form-submitted-lead_form': '', 'lead': new_lead.id})
+        self.assertEqual(response.status_code, 200)
+
+        project.refresh_from_db()
+        self.assertEqual(project.lead, new_lead)
+
+    def test_update_lead_from_none(self):
+        project = ProjectFactory(lead=None)
+
+        new_lead = self.user_factory()
+        response = self.post_page(project, {'form-submitted-lead_form': '', 'lead': new_lead.id})
+        self.assertEqual(response.status_code, 200)
+
+        project.refresh_from_db()
+        self.assertEqual(project.lead, new_lead)
+
+
 class TestCreateApprovalView(BaseViewTestCase):
     base_view_name = 'detail'
     url_name = 'funds:projects:{}'

--- a/opentech/apply/projects/views/project.py
+++ b/opentech/apply/projects/views/project.py
@@ -243,7 +243,7 @@ class UpdateLeadView(DelegatedViewMixin, UpdateView):
 
     def form_valid(self, form):
         # Fetch the old lead from the database
-        old = copy(self.get_object())
+        old_lead = copy(self.get_object().lead)
 
         response = super().form_valid(form)
 
@@ -252,7 +252,7 @@ class UpdateLeadView(DelegatedViewMixin, UpdateView):
             request=self.request,
             user=self.request.user,
             source=form.instance,
-            related=old.lead or 'Unassigned',
+            related=old_lead or 'Unassigned',
         )
 
         return response

--- a/opentech/apply/projects/views/project.py
+++ b/opentech/apply/projects/views/project.py
@@ -63,7 +63,7 @@ from ..models import (
     Project
 )
 from ..tables import (
-    PaymentRequestsDashboardTable,
+    PaymentRequestsListTable,
     ProjectsListTable
 )
 
@@ -559,7 +559,7 @@ class ProjectOverviewView(TemplateView):
 
         return {
             'filterset': PaymentRequestListFilter(request.GET or None, request=request, queryset=payment_requests),
-            'table': PaymentRequestsDashboardTable(payment_requests, order_by=()),
+            'table': PaymentRequestsListTable(payment_requests, order_by=()),
             'url': reverse('apply:projects:payments:all'),
         }
 

--- a/opentech/apply/utils/tests/test_views.py
+++ b/opentech/apply/utils/tests/test_views.py
@@ -25,4 +25,3 @@ class TestDelegatedViewMixin(TestCase):
         view.object = 3
         self.assertNotEqual(view.get_object(), 3)
         self.assertEqual(view.get_object(), 1)
-

--- a/opentech/apply/utils/tests/test_views.py
+++ b/opentech/apply/utils/tests/test_views.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from django.views.generic import UpdateView
+
+from opentech.apply.utils.views import DelegatedViewMixin
+
+
+class PatchedUpdateView(UpdateView):
+    def get_object(self):
+        return 1
+
+
+class DelegatedView(DelegatedViewMixin, PatchedUpdateView):
+    model = int  # pretend int is a model for the isinstance check
+
+    def get_parent_kwargs(self):
+        return {'instance': 3}
+
+
+class TestDelegatedViewMixin(TestCase):
+    def test_parent_access_if_no_object(self):
+        self.assertEqual(DelegatedView().get_object(), 3)
+
+    def test__access_if_no_object(self):
+        view = DelegatedView()
+        view.object = 3
+        self.assertNotEqual(view.get_object(), 3)
+        self.assertEqual(view.get_object(), 1)
+

--- a/opentech/apply/utils/views.py
+++ b/opentech/apply/utils/views.py
@@ -134,11 +134,14 @@ class DelegatedViewMixin(View):
         self.kwargs = kwargs
 
     def get_object(self):
-        # We want to make sure we share the same instance between the form
-        # and the view where appropriate
-        parent_object = self.get_parent_kwargs()['instance']
-        if isinstance(parent_object, self.model):
-            return parent_object
+        # Make sure the form instance, bound at the parent class level,  is the same as the
+        # value we work with on the class.
+        # If we don't have self.object, bind the parent instance to it. This value will then
+        # be used by the form. Any further calls to get_object will get a new instance of the object
+        if not hasattr(self, 'object'):
+            parent_object = self.get_parent_object()
+            if isinstance(parent_object, self.model):
+                return parent_object
 
         return super().get_object()
 


### PR DESCRIPTION
Fixes a range of issues in the sprint 3 branch around user experience.
* Increased wording on modals for better clarity
* Changed order and displayed text for payment request tables.

* fixed a bug where the id `id-document` was used twice in the page preventing the file chooser to open.
* fixed a bug where `get_object` was always returning the same object regardless of if we wanted it to.
* Prevent performance issues when instantiating submissions by making categories lazy objects
  - improved performance when iterating over many submissions which never look up category
* Change pagination to use a non counting version so that the query is not evaluated. 
  - Table querysets are complex and doing count on this is very expensive and this can reduce `/all` page load times by ~50% 
