### PR TITLE
Fix: New file versions created on status update, adding partner forms

### DIFF
--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -598,10 +598,12 @@ class ApplicationSubmission(
                         f.save()
                 self.form_data[field.id] = file
 
-    def save(self, *args, update_fields=list(), **kwargs):
+    def save(self, *args, update_fields=list(), skip_custom=False, **kwargs):
         if update_fields and 'form_data' not in update_fields:
             # We don't want to use this approach if the user is sending data
             return super().save(*args, update_fields=update_fields, **kwargs)
+        elif skip_custom:
+            return super().save(*args, **kwargs)
 
         if self.is_draft:
             raise ValueError('Cannot save with draft data')


### PR DESCRIPTION
Fixes #1572

We have various Update forms on submission detail page like a status update, partners, lead forms etc. Application submission model has a custom [save](https://github.com/OpenTechFund/opentech.fund/blob/9a740785a3f6375cc8ec4dd95dcce90de747033f/opentech/apply/funds/models/submissions.py#L601) method. And a portion of the code [saves](https://github.com/OpenTechFund/opentech.fund/blob/9a740785a3f6375cc8ec4dd95dcce90de747033f/opentech/apply/funds/models/submissions.py#L595) a new version of a file every time save method is invoked. It results in long filenames as file overwrite setting is False. The update forms on detail page do not need to run the custom code in the save method. Therefore adding a flag to skip the custom operation for these forms. This old PR #558 also seems related. For the future, we should refactor the file save behaviour in save call.