### PR TITLE
Fix the creation of files under the submission's revision path 

### DIFF
--- a/opentech/apply/funds/files.py
+++ b/opentech/apply/funds/files.py
@@ -14,7 +14,13 @@ def generate_submission_file_path(submission_id, field_id, file_name):
 
 class SubmissionStreamFieldFile(StreamFieldFile):
     def generate_filename(self):
-        return generate_submission_file_path(self.instance.pk, self.field.id, self.name)
+        from opentech.apply.funds.models.submissions import ApplicationRevision
+        submission_id = self.instance.pk
+
+        if isinstance(self.instance, ApplicationRevision):
+            submission_id = self.instance.submission.pk
+
+        return generate_submission_file_path(submission_id, self.field.id, self.name)
 
     @property
     def url(self):

--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -67,12 +67,18 @@ class AccessFormData:
         else:
             return cls.stream_file(instance, field, file)
 
-    def process_file_data(self, data):
+    def process_file_data(self, data, current_data=None):
         for field in self.form_fields:
             if isinstance(field.block, UploadableMediaBlock):
                 file = self.process_file(self, field, data.get(field.id, []))
                 try:
-                    file.save()
+                    if current_data:
+                        current_file = current_data.get(field.id)
+                        # Save file only when the file is changed
+                        if current_file != file:
+                            file.save()
+                    else:
+                        file.save()
                 except AttributeError:
                     for f in file:
                         f.save()

--- a/opentech/apply/funds/models/mixins.py
+++ b/opentech/apply/funds/models/mixins.py
@@ -67,18 +67,12 @@ class AccessFormData:
         else:
             return cls.stream_file(instance, field, file)
 
-    def process_file_data(self, data, current_data=None):
+    def process_file_data(self, data):
         for field in self.form_fields:
             if isinstance(field.block, UploadableMediaBlock):
                 file = self.process_file(self, field, data.get(field.id, []))
                 try:
-                    if current_data:
-                        current_file = current_data.get(field.id)
-                        # Save file only when the file is changed
-                        if current_file != file:
-                            file.save()
-                    else:
-                        file.save()
+                    file.save()
                 except AttributeError:
                     for f in file:
                         f.save()

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -545,9 +545,11 @@ class ApplicationSubmission(
 
     def create_revision(self, draft=False, force=False, by=None, **kwargs):
         # Will return True/False if the revision was created or not
-        self.clean_submission()
         current_submission = ApplicationSubmission.objects.get(id=self.id)
         current_data = current_submission.form_data
+        self.clean_submission(current_data)
+        self.search_data = ' '.join(self.prepare_search_values())
+
         if current_data != self.form_data or force:
             if self.live_revision == self.draft_revision:
                 revision = ApplicationRevision.objects.create(submission=self, form_data=self.form_data, author=by)
@@ -567,10 +569,10 @@ class ApplicationSubmission(
             return revision
         return None
 
-    def clean_submission(self):
+    def clean_submission(self, current_data=None):
         self.process_form_data()
         self.ensure_user_has_account()
-        self.process_file_data(self.form_data)
+        self.process_file_data(self.form_data, current_data)
 
     def process_form_data(self):
         for field_name, field_id in self.named_blocks.items():

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -563,7 +563,7 @@ class ApplicationSubmission(
                 self.live_revision = revision
 
             self.draft_revision = revision
-            self.save()
+            self.save(skip_custom=True)
             return revision
         return None
 

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -545,11 +545,9 @@ class ApplicationSubmission(
 
     def create_revision(self, draft=False, force=False, by=None, **kwargs):
         # Will return True/False if the revision was created or not
+        self.clean_submission()
         current_submission = ApplicationSubmission.objects.get(id=self.id)
         current_data = current_submission.form_data
-        self.clean_submission(current_data)
-        self.search_data = ' '.join(self.prepare_search_values())
-
         if current_data != self.form_data or force:
             if self.live_revision == self.draft_revision:
                 revision = ApplicationRevision.objects.create(submission=self, form_data=self.form_data, author=by)
@@ -569,10 +567,10 @@ class ApplicationSubmission(
             return revision
         return None
 
-    def clean_submission(self, current_data=None):
+    def clean_submission(self):
         self.process_form_data()
         self.ensure_user_has_account()
-        self.process_file_data(self.form_data, current_data)
+        self.process_file_data(self.form_data)
 
     def process_form_data(self):
         for field_name, field_id in self.named_blocks.items():

--- a/opentech/apply/funds/models/submissions.py
+++ b/opentech/apply/funds/models/submissions.py
@@ -561,6 +561,7 @@ class ApplicationSubmission(
                 self.form_data = current_submission.form_data
             else:
                 self.live_revision = revision
+                self.search_data = ' '.join(self.prepare_search_values())
 
             self.draft_revision = revision
             self.save(skip_custom=True)

--- a/opentech/apply/funds/tests/test_models.py
+++ b/opentech/apply/funds/tests/test_models.py
@@ -402,6 +402,24 @@ class TestApplicationSubmission(TestCase):
         # Check we saved the file somewhere beneath it
         self.assertIn(filename, found_files)
 
+    def test_correct_file_path_generated(self):
+        submission = ApplicationSubmissionFactory()
+
+        for file_id in submission.file_field_ids:
+
+            def check_generated_file_path(file_to_test):
+                file_path_generated = file_to_test.generate_filename()
+                file_path_required = os.path.join('submission', str(submission.id), str(file_id), file_to_test.basename)
+
+                self.assertEqual(file_path_generated, file_path_required)
+
+            file_response = submission.data(file_id)
+            if isinstance(file_response, list):
+                for stream_file in file_response:
+                    check_generated_file_path(stream_file)
+            else:
+                check_generated_file_path(file_response)
+
     def test_create_revision_on_create(self):
         submission = ApplicationSubmissionFactory()
         self.assertEqual(submission.revisions.count(), 1)


### PR DESCRIPTION
Not related to the issue fixed. But we may need a strategy to only [save](https://github.com/OpenTechFund/opentech.fund/blob/2ffd404d628ad4f255ac3892cef306980f6e4a4d/opentech/apply/funds/models/mixins.py#L75) files if the existing files changes. Currently, a new file version is created even if the file is not changed in an edit form. Long file names have problems like #1572.

Fixes https://github.com/OpenTechFund/issues.otf/issues/13