### PR TITLE
Use FileResponse as in Django 2.1 it tries to set the Content-Type, Content-Length headers

### DIFF
--- a/opentech/apply/utils/storage.py
+++ b/opentech/apply/utils/storage.py
@@ -1,10 +1,6 @@
-import mimetypes
-import os
-from wsgiref.util import FileWrapper
-
 from django.conf import settings
 from django.core.files.storage import get_storage_class
-from django.http import StreamingHttpResponse
+from django.http import FileResponse
 from django.views.generic import View
 
 
@@ -21,21 +17,4 @@ class PrivateMediaView(View):
 
     def get(self, *args, **kwargs):
         file_to_serve = self.get_media(*args, **kwargs)
-        wrapper = FileWrapper(file_to_serve)
-        encoding_map = {
-            'bzip2': 'application/x-bzip',
-            'gzip': 'application/gzip',
-            'xz': 'application/x-xz',
-        }
-        file_name = os.path.basename(file_to_serve.name)
-        content_type, encoding = mimetypes.guess_type(file_name)
-        # Encoding isn't set to prevent browsers from automatically uncompressing files.
-        content_type = encoding_map.get(encoding, content_type)
-        content_type = content_type or 'application/octet-stream'
-        # From Django 2.1, we can use FileResponse instead of StreamingHttpResponse
-        response = StreamingHttpResponse(wrapper, content_type=content_type)
-
-        response['Content-Disposition'] = f'filename={file_name}'
-        response['Content-Length'] = file_to_serve.size
-
-        return response
+        return FileResponse(file_to_serve)


### PR DESCRIPTION
>The new as_attachment argument for FileResponse sets the Content-Disposition header to make the browser ask if the user wants to download the file. FileResponse also tries to set the Content-Type and Content-Length headers where appropriate. - release [docs](https://docs.djangoproject.com/en/2.1/releases/2.1/#requests-and-responses).