### PR TITLE
Fixes for Batch Determination creation

### DIFF
--- a/opentech/apply/activity/messaging.py
+++ b/opentech/apply/activity/messaging.py
@@ -778,7 +778,7 @@ class EmailAdapter(AdapterBase):
         except AttributeError:  # we're dealing with a project
             from_email = source.submission.page.specific.from_address
         except Exception as e:
-            from_address = None
+            from_email = None
             logger.exception(e)
 
         try:

--- a/opentech/apply/determinations/views.py
+++ b/opentech/apply/determinations/views.py
@@ -142,7 +142,7 @@ class BatchDeterminationCreateView(CreateView):
                         message=determination.stripped_message,
                         timestamp=timezone.now(),
                         user=self.request.user,
-                        submission=submission,
+                        source=submission,
                         related_object=determination,
                     )
 

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -325,7 +325,7 @@ SHORT_DATETIME_FORMAT = 'Y-m-d\TH:i:s'
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/stable/howto/static-files/
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 STATICFILES_DIRS = [
     os.path.join(PROJECT_DIR, 'static_compiled'),

--- a/opentech/settings/base.py
+++ b/opentech/settings/base.py
@@ -325,7 +325,7 @@ SHORT_DATETIME_FORMAT = 'Y-m-d\TH:i:s'
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/stable/howto/static-files/
 
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 STATICFILES_DIRS = [
     os.path.join(PROJECT_DIR, 'static_compiled'),


### PR DESCRIPTION
Fixes: #1705

1. AttributeError: 'NoneType' object has no attribute 'page'

```shell
  File "opentech/apply/activity/messaging.py", line 778, in send_message
    from_email = source.submission.page.specific.from_address
```

Methods in messaging code use `source` value. In the case of the batch, the `source` is None. Therefore, errors like the above occur. Included code to extract `source` value from `sources` in `process_send` method so other methods can use the `source` value.

2. 
```shell
Exception Type: TypeError at /apply/submissions/batch-determine/
Exception Value: Direct assignment to the reverse side of a related set is prohibited. Use submission.set() instead.
```

Recently Activity model has updated and replaced `submission` field with a generic `source` field. Updated the code which was left behind earlier and included a test.