### PR TITLE
Enhancement/gh 3065 allow undo determinations

### DIFF
--- a/hypha/apply/determinations/utils.py
+++ b/hypha/apply/determinations/utils.py
@@ -30,7 +30,10 @@ def transition_from_outcome(outcome, submission):
 
 
 def has_final_determination(submission):
-    # This was `submission.determinations.final().exists()` but in #9 ARDC asked
+    # This was `submission.determinations.final().exists()` but in #3065 we wanted 
     # to be able to revert after a determination has been made and presumably
     # make a new determination, so no determinations are truly final.
+    #
+    # Keeping around for legacy reasons, but may be better to just update the logic
+    # everywhere that uses this method.
     return False

--- a/hypha/apply/determinations/utils.py
+++ b/hypha/apply/determinations/utils.py
@@ -30,4 +30,7 @@ def transition_from_outcome(outcome, submission):
 
 
 def has_final_determination(submission):
-    return submission.determinations.final().exists()
+    # This was `submission.determinations.final().exists()` but in #9 ARDC asked
+    # to be able to revert after a determination has been made and presumably
+    # make a new determination, so no determinations are truly final.
+    return False

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -419,7 +419,7 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
     def should_redirect(cls, request, submission, action):
         if has_final_determination(submission):
             determination = submission.determinations.final().first()
-            if action not in TRANSITION_DETERMINATION or determination.outcome == TRANSITION_DETERMINATION[action]:
+            if determination.outcome == TRANSITION_DETERMINATION[action]:
                 # We want to progress as normal so don't redirect through form
                 return False
             else:

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -419,7 +419,7 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
     def should_redirect(cls, request, submission, action):
         if has_final_determination(submission):
             determination = submission.determinations.final().first()
-            if determination.outcome == TRANSITION_DETERMINATION[action]:
+            if action not in TRANSITION_DETERMINATION or determination.outcome == TRANSITION_DETERMINATION[action]:
                 # We want to progress as normal so don't redirect through form
                 return False
             else:

--- a/hypha/apply/funds/tests/test_views.py
+++ b/hypha/apply/funds/tests/test_views.py
@@ -135,26 +135,6 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
         self.assertEqual(submission.status, 'concept_review_discussion')
         self.assertIsNone(submission.next)
 
-    def test_not_redirected_if_determination_submitted(self):
-        submission = ApplicationSubmissionFactory(lead=self.user)
-        DeterminationFactory(submission=submission, rejected=True, submitted=True)
-
-        self.post_page(submission, {'form-submitted-progress_form': '', 'action': 'rejected'})
-
-        submission = self.refresh(submission)
-        self.assertEqual(submission.status, 'rejected')
-
-    def test_not_redirected_if_wrong_determination_selected(self):
-        submission = ApplicationSubmissionFactory(lead=self.user)
-        DeterminationFactory(submission=submission, accepted=True, submitted=True)
-
-        response = self.post_page(submission, {'form-submitted-progress_form': '', 'action': 'rejected'})
-        self.assertContains(response, 'you tried to progress')
-
-        submission = self.refresh(submission)
-        self.assertNotEqual(submission.status, 'accepted')
-        self.assertNotEqual(submission.status, 'rejected')
-
     def test_cant_access_edit_button_when_applicant_editing(self):
         submission = ApplicationSubmissionFactory(status='more_info')
         response = self.get_page(submission)
@@ -499,6 +479,12 @@ class TestStaffSubmissionView(BaseSubmissionViewTestCase):
 
         response = SubmissionDetailView.as_view()(request, pk=submission.pk)
         self.assertEqual(response.status_code, 200)
+
+    def test_can_revert_determined_submission(self):
+        submission = ApplicationSubmissionFactory(lead=self.user, with_external_review=True, status='ext_rejected')
+        self.post_page(submission, {'form-submitted-progress_form': '', 'action': 'ext_external_review'})
+        submission = self.refresh(submission)
+        self.assertEqual(submission.status, 'ext_external_review')
 
 
 class TestReviewersUpdateView(BaseSubmissionViewTestCase):

--- a/hypha/apply/funds/tests/views/test_batch_progress.py
+++ b/hypha/apply/funds/tests/views/test_batch_progress.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-from hypha.apply.determinations.tests.factories import DeterminationFactory
 from hypha.apply.funds.models import ApplicationSubmission
 from hypha.apply.funds.tests.factories import (
     ApplicationSubmissionFactory,
@@ -68,14 +67,6 @@ class StaffTestCase(BaseBatchProgressViewTestCase):
         other_submission = self.refresh(other_submission)
         self.assertEqual(submission.status, 'internal_review')
         self.assertEqual(other_submission.status, 'proposal_internal_review')
-
-    def test_mixed_determine_notifies(self):
-        submission = ApplicationSubmissionFactory()
-        dismissed_submission = ApplicationSubmissionFactory(status='rejected')
-        DeterminationFactory(submission=dismissed_submission, rejected=True, submitted=True)
-        action = 'dismiss'
-        response = self.post_page(data=self.data(action, [submission, dismissed_submission]))
-        self.assertEqual(len(response.context['messages']), 1)
 
     def test_determine_redirects(self):
         submission = ApplicationSubmissionFactory()

--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -453,6 +453,9 @@ SingleStageExternalDefinition = [
     },
     {
         'ext_accepted': {
+            'transitions': {
+                'ext_external_review': _('Open Internal Review (revert)'),
+            },
             'display': _('Accepted'),
             'future': _('Application Outcome'),
             'stage': RequestExt,
@@ -468,6 +471,9 @@ SingleStageExternalDefinition = [
             'permissions': applicant_edit_permissions,
         },
         'ext_rejected': {
+            'transitions': {
+                'ext_external_review': _('Open Internal Review (revert)'),
+            },
             'display': _('Dismissed'),
             'stage': RequestExt,
             'permissions': no_permissions,


### PR DESCRIPTION
Fixes #3065

This adds the ability to undo determinations, sending them back back to external review.  While this doesn't remove the determinations (delete no data), it will add to them. That means, if the submission reaches the determination phase again, it will have multiple determinations.
