### PR TITLE
Disable submission preview until a fix for the bugs are in place.

### DIFF
--- a/hypha/apply/funds/templates/funds/application_base.html
+++ b/hypha/apply/funds/templates/funds/application_base.html
@@ -75,7 +75,8 @@
                             <button class="button button--submit button--primary" type="submit" disabled>{% trans "Submit for review" %}</button>
                         {% endif %}
                         <button class="button button--submit button--white" type="submit" name="draft" value="Save draft" formnovalidate>{% trans "Save draft" %}</button>
-                        {% if not require_preview and request.user.is_authenticated %}
+                        # TODO Fix preview bugs before reactivating.
+                        {% if False and not require_preview and request.user.is_authenticated %}
                             <button class="button button--submit button--white" type="submit" name="preview">{% trans "Preview" %}</button>
                         {% endif %}
                     </div>

--- a/hypha/apply/funds/views.py
+++ b/hypha/apply/funds/views.py
@@ -1311,7 +1311,8 @@ class BaseSubmissionEditView(UpdateView):
         else:
             yield ("submit", "primary", _("Submit"))
             yield ("save", "white", _("Save draft"))
-            yield ("preview", "white", _("Preview"))
+            # TODO Fix preview bugs before reactivating.
+            # yield ("preview", "white", _("Preview"))
 
     def get_form_kwargs(self):
         """

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -148,7 +148,8 @@ TRANSITION_AFTER_REVIEWS = env.bool("TRANSITION_AFTER_REVIEWS", False)
 REVIEW_VISIBILITY_DEFAULT = env.str("REVIEW_VISIBILITY_DEFAULT", "private")
 
 # Require an applicant to view their rendered application before submitting
-SUBMISSION_PREVIEW_REQUIRED = env.bool("SUBMISSION_PREVIEW_REQUIRED", True)
+# TODO Fix preview bugs before setting this to True as default.
+SUBMISSION_PREVIEW_REQUIRED = env.bool("SUBMISSION_PREVIEW_REQUIRED", False)
 
 # Project settings.
 


### PR DESCRIPTION
Related #3788

Sets `SUBMISSION_PREVIEW_REQUIRED` to False by default and hides the submission preview buttons.

We need a permanent fix for the preview bugs but until then this hides the functionality.