### PR TITLE
Fix applicant header layout spacing for mobile

### DIFF
--- a/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/applicant_dashboard.html
@@ -7,7 +7,7 @@
 
 {% block content %}
     <div class="admin-bar">
-        <div class="admin-bar__inner wrapper--applicant-dashboard">
+        <div class="admin-bar__inner wrapper--applicant-dashboard gap-4">
             <div class="my-auto">
                 <h1 class="heading heading--no-margin font-bold">{% trans "My dashboard" %}</h1>
                 <p class="m-0">{% trans "An overview of active and past submissions and projects" %}</p>


### PR DESCRIPTION
## Description
<!--
Describe briefly what your pull request changes. If this is resoving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Add a gap b/w the header title and apply call to action

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

![image](https://github.com/HyphaApp/hypha/assets/236356/b0edcf76-7f17-4447-8e7b-a8749e9db2cd)

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where neccesary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Langauge that can be understood by non-technical testers if being tested by users
-->

 - [ ] Login as applicant
 - [ ] Check the spacing b/w the header title and "submit a new application" box
