### PR TITLE
Show project status header if an application has been upgraded to a project

### DIFF
--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -9,41 +9,14 @@
 {% block content %}
     <div class="admin-bar">
         <div class="admin-bar__inner">
-            {% if request.GET.ref == 'all-alt' %}
-                <a class="admin-bar__back-link"
-                   hx-boost="true"
-                   href="{% url "funds:submissions:list" %}"
-                >
-                    {% trans "Back to submissions" %}
-                </a>
+
+            {% if object.project %}
+                {% include "application_projects/includes/project_header.html" with object=object.project %}
+            {% else %}
+                {% include "funds/includes/application_header.html" %}
             {% endif %}
-            <h1 class="mb-0 font-medium">
-                <span id="app-title">{{ object.title }}</span><span class="text-gray-400"> #{{ object.public_id|default:object.id }}</span>
-            </h1>
-            <div class="mt-1 text-sm font-medium heading heading--meta">
-                <span>{{ object.stage }}</span>
-                <span>{{ object.page }}</span>
-                {% if object.round %}
-                    {% if request.user.is_apply_staff %}
-                        <span>
-                            <a class="text-white underline"
-                               href="{% url 'apply:submissions:list' %}?round={{ object.round.pk }}"
-                            >{{ object.round }}</a>
-                        </span>
-                    {% else %}
-                        <span>{{ object.round }}</span>
-                    {% endif %}
-                {% endif %}
 
-                <span
-                    hx-get="{% url "apply:submissions:partial-get-lead" object.id %}"
-                    hx-trigger="load, leadUpdated from:body"
-                >
-                    <span class="inline-block w-24 bg-gray-600 rounded-md animate-pulse"></span>
-                </span>
-            </div>
 
-            {% status_bar object.workflow object.phase request.user author=object.user same_stage=True %}
 
             <div class="tabs js-tabs">
                 <div class="tabs__container">
@@ -78,20 +51,6 @@
         </div>
     </div>
 
-    {% if object.is_archive %}
-        <div class="py-2 font-bold text-center text-white bg-red-600">
-            {% heroicon_outline "lock-closed" aria_hidden="true" size=16 stroke_width=2 class="inline align-baseline me-1" %}
-            {% trans "This submission has been archived. This is visible to the roles " %} {{ archive_access_groups|join_with_commas }}
-        </div>
-    {% endif %}
-
-    {% if object.round.specific.is_sealed %}
-        <div class="py-2 font-bold text-center text-white bg-red-600">
-            {% heroicon_outline "clock" aria_hidden="true" size=16 stroke_width=2 class="inline align-baseline me-1" %}
-            {% trans "This submission is sealed" %}
-        </div>
-    {% endif %}
-
     <div class="wrapper wrapper--large wrapper--tabs js-tabs-content">
     {# Tab 1 #}
         <div class="tabs__content" id="tab-1">
@@ -104,6 +63,20 @@
                     </div>
                 {% else %}
                     <article class="wrapper--sidebar--inner">
+                        {% if object.is_archive %}
+                            <div class="flex gap-2 justify-center items-center py-2 mb-4 font-semibold text-center text-white bg-red-600 rounded-sm">
+                                {% heroicon_outline "lock-closed" aria_hidden="true" size=16 stroke_width=2 class="inline align-baseline me-1" %}
+                                {% trans "This application has been archived. This is visible to the roles " %} {{ archive_access_groups|join_with_commas }}.
+                            </div>
+                        {% endif %}
+
+                        {% if object.round.specific.is_sealed %}
+                            <div class="flex gap-2 justify-center items-center py-2 mb-4 font-semibold text-center text-white bg-red-600 rounded-sm">
+                                {% heroicon_outline "clock" aria_hidden="true" size=16 stroke_width=2 class="inline align-baseline me-1" %}
+                                {% trans "This application is sealed." %}
+                            </div>
+                        {% endif %}
+
                         <header class="heading heading--submission-meta heading-text zeta">
                             <span>
                                 {% if object.is_draft %}
@@ -232,7 +205,7 @@
         {# Tab 2 #}
         <div class="tabs__content" id="tab-2">
             <div class="feed">
-                {% if not object.is_archive %}
+                {% if not object.is_archive or object.project %}
                     <h4 class="m-0 sr-only">{% trans "Add communication" %}</h4>
                     {% include "activity/include/comment_form.html" %}
                 {% endif %}

--- a/hypha/apply/funds/templates/funds/includes/application_header.html
+++ b/hypha/apply/funds/templates/funds/includes/application_header.html
@@ -1,0 +1,30 @@
+{% load i18n statusbar_tags %}
+
+<h1 class="mb-0 font-medium">
+    <span id="app-title">{{ object.title }}</span><span class="text-gray-400"> #{{ object.public_id|default:object.id }}</span>
+</h1>
+
+<div class="mt-1 text-sm font-medium heading heading--meta">
+    <span>{{ object.stage }}</span>
+    <span>{{ object.page }}</span>
+    {% if object.round %}
+        {% if request.user.is_apply_staff %}
+            <span>
+                <a class="text-white underline"
+                   href="{% url 'apply:submissions:list' %}?round={{ object.round.pk }}"
+                >{{ object.round }}</a>
+            </span>
+        {% else %}
+            <span>{{ object.round }}</span>
+        {% endif %}
+    {% endif %}
+
+    <span
+        hx-get="{% url "apply:submissions:partial-get-lead" object.id %}"
+        hx-trigger="load, leadUpdated from:body"
+    >
+        <span class="inline-block w-24 bg-gray-600 rounded-md animate-pulse"></span>
+    </span>
+</div>
+
+{% status_bar object.workflow object.phase request.user author=object.user same_stage=True %}

--- a/hypha/apply/projects/templates/application_projects/includes/project_header.html
+++ b/hypha/apply/projects/templates/application_projects/includes/project_header.html
@@ -1,0 +1,45 @@
+{% load project_tags dashboard_statusbar_tags %}
+
+{% display_project_status object request.user as project_status %}
+
+<h1
+    class="mb-0 font-medium"
+    hx-get='{% url "apply:projects:project_title" object.submission.id %}'
+    hx-trigger="load, titleUpdated from:body"
+>
+    <span class="inline-block bg-gray-600 rounded-md animate-pulse"></span>
+</h1>
+
+<div class="mt-1 text-sm font-medium heading heading--meta">
+    <span>{{ object.submission.page }}</span>
+
+    {% if object.submission.round %}
+        {% if request.user.is_apply_staff %}
+            <span>
+                <a class="text-white underline"
+                   href="{% url 'apply:submissions:list' %}?round={{ object.submission.round.pk }}"
+                >{{ object.submission.round }}</a>
+            </span>
+        {% else %}
+            {{ object.submission.round }}
+        {% endif %}
+    {% endif %}
+
+    {% if not HIDE_STAFF_IDENTITY or request.user.is_apply_staff %}
+        <span
+            hx-get="{% url "apply:projects:project_lead" object.submission.id %}"
+            hx-trigger="load, leadUpdated from:body"
+        >
+            <span class="inline-block w-24 bg-gray-600 rounded-md animate-pulse"></span>
+        </span>
+    {% endif %}
+
+</div>
+
+<div class="my-6 status-bar">
+    {% project_status_bar object.status request.user css_class="w-full" %}
+</div>
+
+<div class="mt-5 status-bar--mobile">
+    <h6 class="status-bar__subheading">{{ project_status }}</h6>
+</div>

--- a/hypha/apply/projects/templates/application_projects/project_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_detail.html
@@ -8,60 +8,10 @@
 {% block body_class %}{% endblock %}
 
 {% block content %}
-    {% display_project_status object request.user as project_status %}
-    <div class="admin-bar" xmlns="http://www.w3.org/1999/html">
+    <div class="admin-bar">
         <div class="admin-bar__inner">
-            <h1 class="mb-0 font-medium"
-                hx-get="{% url "apply:projects:project_title" object.submission.id %}"
-                hx-trigger="load, titleUpdated from:body"
-            >
-                <span class="inline-block bg-gray-600 rounded-md animate-pulse"></span>
-            </h1>
 
-            <div class="mt-1 text-sm font-medium heading heading--meta">
-
-                <span>{{ object.submission.page }}</span>
-
-                {% if object.submission.round %}
-                    {% if request.user.is_apply_staff %}
-                        <span>
-                            <a class="text-white underline"
-                               href="{% url 'apply:submissions:list' %}?round={{ object.submission.round.pk }}"
-                            >{{ object.submission.round }}</a>
-                        </span>
-                    {% else %}
-                        {{ object.submission.round }}
-                    {% endif %}
-                {% endif %}
-
-                {% if not HIDE_STAFF_IDENTITY or request.user.is_apply_staff %}
-                    <span
-                        hx-get="{% url "apply:projects:project_lead" object.submission.id %}"
-                        hx-trigger="load, leadUpdated from:body"
-                    >
-                        <span class="inline-block w-24 bg-gray-600 rounded-md animate-pulse"></span>
-                    </span>
-                {% endif %}
-
-            </div>
-
-            <div class="my-6 status-bar">
-                {% for status, text in statuses %}
-                    {% if forloop.counter0 == current_status_index %}
-                        {% include "funds/includes/status_bar_item.html" with is_current=True is_complete=False label=text %}
-                    {% elif forloop.counter0 < current_status_index %}
-                        {% include "funds/includes/status_bar_item.html" with is_current=False is_complete=True label=text %}
-                    {% else %}
-                        {% include "funds/includes/status_bar_item.html" with is_current=False is_complete=False label=text %}
-                    {% endif %}
-                {% endfor %}
-            </div>
-
-            <div class="mt-5 status-bar--mobile">
-                <h6 class="status-bar__subheading">
-                    {{ project_status }}
-                </h6>
-            </div>
+            {% include "application_projects/includes/project_header.html" %}
 
             <div class="tabs js-tabs">
                 <div class="tabs__container">


### PR DESCRIPTION
Part 1 of:
- https://github.com/HyphaApp/hypha/issues/4355

Depends on:
- https://github.com/HyphaApp/hypha/pull/3944

Update the detail pages for submissions, communications, and projects to use the same status header when an application has transitioned to a project.

The header behavior mimics the status bar display for concept and proposal applications, showing the proposal stages as the application moves from the concept phase to the proposal phase.

It reuses the existing status bar generation template tag. DRY!

Also, enable the communication form if the submission is archived but the project is active.

## Test Steps
- Verify that a user can leave a comment in archived submission mode if it has an associated project, by navigating to the URL /submissions/[id]/#communications.
- If an application has an associated project, ensure the project's status header is displayed.
