### PR TITLE
Make file uploads after a preview work.

### DIFF
--- a/hypha/apply/funds/views/submission_edit.py
+++ b/hypha/apply/funds/views/submission_edit.py
@@ -97,10 +97,6 @@ class BaseSubmissionEditView(UpdateView):
         self.object.create_revision(draft=True, by=request.user)
         messages.success(self.request, _("Draft saved"))
 
-        # Required for django-file-form: delete temporary files for the new files
-        # uploaded while edit.
-        form.delete_temporary_files()
-
         context = self.get_context_data()
         return render(request, "funds/application_preview.html", context)
 


### PR DESCRIPTION
Fixes #4556

We need to test that removing `form.delete_temporary_files()` from `render_preview` does not have any bad side effects. My guess is that it is conflicting with (not needed after) https://github.com/HyphaApp/hypha/pull/4499.

## Test Steps

 - [ ] 1. Open a new application form that has file uploads. 
 - [ ] 2. Fill in some fields but do not add any files. 
 - [ ] 3. Hit preview and then opt to edit the application. 
 - [ ] 4. Add some file(s). 
 - [ ] 5. Preview and then submit.
 - [ ] 6. Confirm that the files exist in the application.