### PR TITLE
Fix co-applicant permission for Partners, Reviewers, and Community Reviewers

### DIFF
--- a/hypha/apply/funds/views/submission_detail.py
+++ b/hypha/apply/funds/views/submission_detail.py
@@ -115,7 +115,11 @@ class ReviewerSubmissionDetailView(ActivityContextMixin, DetailView):
         submission = self.get_object()
         # If the requesting user submitted the application, return the Applicant view.
         # Reviewers may sometimes be applicants as well.
-        if submission.user == request.user:
+        # or if requesting user is a co-applicant to application, return the Applicant view.
+        if (
+            submission.user == request.user
+            or submission.co_applicants.filter(user=request.user).exists()
+        ):
             return ApplicantSubmissionDetailView.as_view()(request, *args, **kwargs)
         if submission.status == DRAFT_STATE:
             raise Http404
@@ -149,7 +153,11 @@ class PartnerSubmissionDetailView(ActivityContextMixin, DetailView):
         )
         # If the requesting user submitted the application, return the Applicant view.
         # Partners may sometimes be applicants as well.
-        if submission.user == request.user:
+        # or if requesting user is a co-applicant to application, return the Applicant view.
+        if (
+            submission.user == request.user
+            or submission.co_applicants.filter(user=request.user).exists()
+        ):
             return ApplicantSubmissionDetailView.as_view()(request, *args, **kwargs)
         # Only allow partners in the submission they are added as partners
         partner_has_access = submission.partners.filter(pk=request.user.pk).exists()
@@ -171,7 +179,11 @@ class CommunitySubmissionDetailView(ActivityContextMixin, DetailView):
         )
         # If the requesting user submitted the application, return the Applicant view.
         # Reviewers may sometimes be applicants as well.
-        if submission.user == request.user:
+        # or if requesting user is a co-applicant to application, return the Applicant view.
+        if (
+            submission.user == request.user
+            or submission.co_applicants.filter(user=request.user).exists()
+        ):
             return ApplicantSubmissionDetailView.as_view()(request, *args, **kwargs)
         # Only allow community reviewers in submission with a community review state.
         if not submission.community_review:


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4578 

These views are using custom permissions along with submission_view permission, and those custom permissions are causing issues. Now, we have checked if a user with the role of Partner, Reviewer, and Community Reviewer isan  applicant or a co-applicant will be redirected to Applicant view.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Try to invite any role as a co-applicant
 - [ ] Accept the invite by become that user and check if submission is accessible or not.