### PR TITLE
Make timestamp consistent for projects

### DIFF
--- a/hypha/apply/projects/templates/application_projects/partials/invoice_status.html
+++ b/hypha/apply/projects/templates/application_projects/partials/invoice_status.html
@@ -7,7 +7,11 @@
     {% extract_status latest_activity user as latest_activity_status %}
     {% get_comment_for_invoice_action object latest_activity as latest_activity_comment %}
     <p>{{ latest_activity_status }} {% if user.is_applicant and latest_activity.user != user %} ({{ ORG_SHORT_NAME }}){% else %}({{ latest_activity.user }}){% endif %}
-        <span class="text-gray-400">{{ latest_activity.timestamp }}</span>
+        <span class="text-gray-400">
+            <relative-time datetime="{{ latest_activity.timestamp|date:'c' }}">
+                {{ latest_activity.timestamp|date:'SHORT_DATETIME_FORMAT' }}
+            </relative-time>
+        </span>
 
         {% if latest_activity_comment %}
             {% heroicon_outline "exclamation-circle" stroke_width=2 size=22 class="inline stroke-red-500" aria_hidden=true %}
@@ -21,7 +25,11 @@
         {% extract_status activity user as activity_status %}
         {% get_comment_for_invoice_action object activity as activity_comment %}
         <p x-show="!collapsed">{{ activity_status }} {% if user.is_applicant and activity.user != user %} ({{ ORG_SHORT_NAME }}){% else %}({{ activity.user }}){% endif %}
-            <span class="text-gray-400">{{ activity.timestamp }}</span>
+            <span class="text-gray-400">
+                <relative-time datetime="{{ activity.timestamp|date:'c' }}">
+                    {{ activity.timestamp|date:'SHORT_DATETIME_FORMAT' }}
+                </relative-time>
+            </span>
             {% if activity_comment %}
                 {% heroicon_outline "exclamation-circle" stroke_width=2 size=22 class="inline stroke-red-500" aria_hidden=true %}
                 <a


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4528 

In projects, we use only dates(no timestamp) in most places. I found the timestamp only at two places that too from activities. One of them is in invoice_detail page that has updated in this PR, another is in the pdf_invoice_approved_page.html, which is in a generated PDF so relative time won't make sense here.

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Check timestamps around project(including invoices, reports) and it should be relative time everywhere.