### PR TITLE
Implement updated print styles.

### DIFF
--- a/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_detail.html
@@ -14,7 +14,7 @@
             {% include "funds/includes/application_header.html" %}
         {% endif %}
 
-        <div role="tablist" class="font-medium tabs tabs-lg tabs-lift text-base-content">
+        <div role="tablist" class="font-medium tabs tabs-lg tabs-lift text-base-content print-hidden">
             <a
                 class="tab tab-active"
                 href="{% url 'funds:submissions:detail' pk=object.id %}"
@@ -102,7 +102,7 @@
                             </div>
                         </div>
 
-                        <div class="flex flex-1 gap-2 justify-end items-center print:!hidden">
+                        <div class="flex flex-1 gap-2 justify-end items-center print-hidden">
                             {% if request.user|has_edit_perm:object %}
                                 <a
                                     class="btn btn-soft btn-secondary btn-sm"

--- a/hypha/apply/funds/templates/funds/comments.html
+++ b/hypha/apply/funds/templates/funds/comments.html
@@ -11,7 +11,7 @@
             {% include "funds/includes/application_header.html" %}
         {% endif %}
 
-        <div role="tablist" class="font-medium tabs tabs-lg tabs-lift text-base-content">
+        <div role="tablist" class="font-medium tabs tabs-lg tabs-lift text-base-content print-hidden">
             <a
                 class="tab [--color-base-content:var(--color-neutral-content)]"
                 href="{% url 'funds:submissions:detail' pk=object.id %}">

--- a/hypha/apply/funds/templates/funds/includes/application_header.html
+++ b/hypha/apply/funds/templates/funds/includes/application_header.html
@@ -36,6 +36,6 @@
     </span>
 </div>
 
-<div class="mt-4 mb-8 print:!hidden">
+<div class="mt-4 mb-8 print-hidden">
     {% status_bar object.workflow object.phase request.user author=object.user same_stage=True %}
 </div>

--- a/hypha/apply/projects/templates/application_projects/includes/project_header.html
+++ b/hypha/apply/projects/templates/application_projects/includes/project_header.html
@@ -36,6 +36,6 @@
     {% endif %}
 </div>
 
-<div class="mt-4 mb-8 print:!hidden">
+<div class="mt-4 mb-8 print-hidden">
     {% project_status_bar object.status request.user css_class="w-full" %}
 </div>

--- a/hypha/apply/projects/templates/application_projects/project_detail.html
+++ b/hypha/apply/projects/templates/application_projects/project_detail.html
@@ -9,7 +9,7 @@
     <c-hero padding="pt-4">
         {% include "application_projects/includes/project_header.html" %}
 
-        <div role="tablist" class="font-medium tabs tabs-lg tabs-lift text-base-content">
+        <div role="tablist" class="font-medium tabs tabs-lg tabs-lift text-base-content print-hidden">
             <a
                 class="tab [--color-base-content:var(--color-neutral-content)]"
                 href="{{ project.submission.get_absolute_url }}"

--- a/hypha/cookieconsent/templates/includes/banner.html
+++ b/hypha/cookieconsent/templates/includes/banner.html
@@ -5,7 +5,7 @@
         x-cloak
         x-data="cookieConsent"
         x-show="isOpen"
-        class="fixed inset-x-0 bottom-0 z-20 py-8 w-full bg-base-200 print:!hidden"
+        class="fixed inset-x-0 bottom-0 z-20 py-8 w-full bg-base-200 print-hidden"
     >
         <div class="container-constrained">
             <div x-show="!showLearnMore">

--- a/hypha/static_src/sass/print.css
+++ b/hypha/static_src/sass/print.css
@@ -1,4 +1,4 @@
-/* stylelint-disable property-no-vendor-prefix, selector-class-pattern */
+/* Print styles. */
 
 * {
   background: transparent !important;
@@ -7,8 +7,7 @@
   box-shadow: none !important;
   text-shadow: none !important;
   filter: none !important;
-  -ms-filter: none !important;
-  font-family: "Garamond Premier Pro", serif !important;
+  font-family: ui-serif, serif !important;
   font-style: normal !important;
   letter-spacing: normal !important;
   text-align: start !important;
@@ -20,16 +19,22 @@ html {
 
 @page {
   margin: 1cm !important;
-  size: letter;
+  margin-inline-start: 1.5cm !important;
 }
 
 body {
-  font-size: 14px !important;
+  font-size: 12px !important;
   line-height: 1.3 !important;
-  margin: 1cm !important;
+  margin: 0 !important;
 }
 
-/* Underline all links. */
+/* Set print styles on tailwind prose class. */
+.prose {
+  font-size: 12px !important;
+  line-height: 1.3 !important;
+}
+
+/* All links as plain text. */
 :link,
 :visited {
   text-decoration: none !important;
@@ -59,29 +64,22 @@ h3 {
 
 h2,
 h3 {
-  page-break-after: avoid;
+  break-after: avoid;
 }
 
-.header__logo {
-  fill: #000;
+/* Set sidebar width to zero since we hide it on print. */
+.layout {
+  --layout-sidebar-width: 0;
 }
 
-.header {
-  height: auto;
-  padding: 0;
-
-  &::after {
-    background: transparent !important;
-  }
+/* When tailwind print:!hidden! refuse to work. */
+.print-hidden {
+  display: none !important;
 }
 
+[aria-hidden],
 nav,
 aside,
-footer,
-.icon,
-.card__icon,
-.tabs__container,
-.cookieconsent,
-.djhj {
+footer {
   display: none !important;
 }

--- a/hypha/templates/base-apply.html
+++ b/hypha/templates/base-apply.html
@@ -21,7 +21,7 @@
         {% endblock %}
 
         {% block user_menu %}
-            <div class="flex gap-2 print:!hidden">
+            <div class="flex gap-2 print-hidden">
 
                 <button class="theme-toggle btn btn-circle btn-soft btn-secondary" data-tippy-content="{% trans 'Toggle color theme' %}">
                     <div class="sr-only theme-label-when-auto">{% trans "Toggle theme" %} ({% trans "current theme" %}: auto)</div>

--- a/hypha/templates/includes/header-logo.html
+++ b/hypha/templates/includes/header-logo.html
@@ -2,14 +2,14 @@
 
 {% if settings.core.SystemSettings.site_logo_default %}
   {% image settings.core.SystemSettings.site_logo_default width-215 as logo_default %}
-  <img class="hidden lg:block header__logo header__logo--desktop" width="215" src="{{ logo_default.url }}" alt="{{ settings.core.SystemSettings.site_logo_default.alt }}" />
+  <img class="hidden lg:block print:block header__logo header__logo--desktop" width="215" src="{{ logo_default.url }}" alt="{{ settings.core.SystemSettings.site_logo_default.alt }}" />
   {% if settings.core.SystemSettings.site_logo_mobile %}
     {% image settings.core.SystemSettings.site_logo_mobile width-60 as logo_mobile %}
-    <img class="block lg:hidden header__logo header__logo--mobile" width="60" src="{{ logo_mobile.url }}" alt="{{ settings.core.SystemSettings.site_logo_mobile.alt }}" />
+    <img class="block lg:hidden print:hidden header__logo header__logo--mobile" width="60" src="{{ logo_mobile.url }}" alt="{{ settings.core.SystemSettings.site_logo_mobile.alt }}" />
   {% else %}
-    <img class="block lg:hidden header__logo header__logo--mobile" width="60" src="{{ logo_default.url }}" alt="{{ settings.core.SystemSettings.site_logo_default.alt }}" />
+    <img class="block lg:hidden print:hidden header__logo header__logo--mobile" width="60" src="{{ logo_default.url }}" alt="{{ settings.core.SystemSettings.site_logo_default.alt }}" />
   {% endif %}
 {% else %}
-  <img class="hidden lg:block header__logo header__logo--desktop" width="215" height="40" src="{% static 'images/logo.png' %}" alt="{% trans 'Hypha logo' %}" />
-  <img class="lg:hidden header__logo header__logo--mobile" width="60" height="60" src="{% static 'images/logo-small.png' %}" alt="{% trans 'Hypha logo' %}" />
+  <img class="hidden lg:block print:block header__logo header__logo--desktop" width="215" height="40" src="{% static 'images/logo.png' %}" alt="{% trans 'Hypha logo' %}" />
+  <img class="lg:hidden print:hidden header__logo header__logo--mobile" width="60" height="60" src="{% static 'images/logo-small.png' %}" alt="{% trans 'Hypha logo' %}" />
 {% endif %}


### PR DESCRIPTION
Concentrated on submission detail view since that is the by far most likely page to be printed.

- [x] Show large logo on print, not mobile version.
- [x] Smaller text and line height on print 12/1.3.
- [x] Add custom `print-hidden` class for when tailwind `print:!hidden` do not work.
- [x] Make print.css as minimal as possible.