### PR TITLE
Fixed old status name showing twice in a transition notification

### DIFF
--- a/hypha/apply/activity/adapters/activity_feed.py
+++ b/hypha/apply/activity/adapters/activity_feed.py
@@ -221,7 +221,7 @@ class ActivityAdapter(AdapterBase):
             )
         )
 
-    def handle_transition(self, old_phase, source, **kwargs):
+    def handle_transition(self, new_phase, source, old_phase=None, **kwargs):
         def wrap_in_color_class(text):
             color_class = PHASE_BG_COLORS.get(text, "")
             return f'<span class="rounded-full inline-block px-2 py-0.5 font-medium text-gray-800 {color_class}">{text}</span>'
@@ -229,7 +229,8 @@ class ActivityAdapter(AdapterBase):
         submission = source
         base_message = _("Progressed from {old_display} to {new_display}")
 
-        new_phase = submission.phase
+        if old_phase is None:
+            old_phase = submission.phase
 
         staff_message = base_message.format(
             old_display=wrap_in_color_class(old_phase.display_name),
@@ -283,8 +284,9 @@ class ActivityAdapter(AdapterBase):
         kwargs.pop("source")
         for submission in submissions:
             old_phase = transitions[submission.id]
+            new_phase = submission.phase
             return self.handle_transition(
-                old_phase=old_phase, source=submission, **kwargs
+                old_phase=old_phase, new_phase=new_phase, source=submission, **kwargs
             )
 
     def partners_updated(self, added, removed, **kwargs):

--- a/hypha/apply/activity/adapters/base.py
+++ b/hypha/apply/activity/adapters/base.py
@@ -8,7 +8,7 @@ neat_related = {
     MESSAGES.BATCH_DETERMINATION_OUTCOME: "determinations",
     MESSAGES.UPDATE_LEAD: "old_lead",
     MESSAGES.NEW_REVIEW: "review",
-    MESSAGES.TRANSITION: "old_phase",
+    MESSAGES.TRANSITION: "new_phase",
     MESSAGES.BATCH_TRANSITION: "transitions",
     MESSAGES.APPLICANT_EDIT: "revision",
     MESSAGES.INVITE_COAPPLICANT: "co_applicant_invite",

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -163,10 +163,14 @@ class EmailAdapter(AdapterBase):
             "subject": self.get_subject(message_type, source),
         }
 
-    def handle_transition(self, old_phase, source, **kwargs):
+    def handle_transition(self, new_phase, source, old_phase=None, **kwargs):
         from hypha.apply.funds.workflows import PHASES
 
         submission = source
+
+        if old_phase is None:
+            old_phase = submission.phase
+
         # Retrieve status index to see if we are going forward or backward.
         old_index = list(dict(PHASES).keys()).index(old_phase.name)
         target_index = list(dict(PHASES).keys()).index(submission.status)
@@ -199,14 +203,14 @@ class EmailAdapter(AdapterBase):
             **kwargs,
         )
 
-    def handle_batch_transition(self, transitions, sources, **kwargs):
-        submissions = sources
-        kwargs.pop("source")
-        for submission in submissions:
-            old_phase = transitions[submission.id]
-            return self.handle_transition(
-                old_phase=old_phase, source=submission, **kwargs
-            )
+    # def handle_batch_transition(self, transitions, sources, **kwargs):
+    #     submissions = sources
+    #     kwargs.pop("source")
+    #     for submission in submissions:
+    #         old_phase = transitions[submission.id]
+    #         return self.handle_transition(
+    #             old_phase=old_phase, source=submission, **kwargs
+    #         )
 
     def handle_project_transition(self, source, **kwargs):
         from hypha.apply.projects.models.project import (

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -175,12 +175,16 @@ class EmailAdapter(AdapterBase):
         old_index = list(dict(PHASES).keys()).index(old_phase.name)
         target_index = list(dict(PHASES).keys()).index(submission.status)
         is_forward = old_index < target_index
+        print("NEW PHASE")
+        print(new_phase.public_name)
+
+        kwargs["old_phase"] = old_phase.public_name
+        kwargs["new_phase"] = new_phase.public_name
 
         if is_forward:
             return self.render_message(
                 "messages/email/transition.html",
                 source=submission,
-                old_phase=old_phase,
                 **kwargs,
             )
 

--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -203,14 +203,15 @@ class EmailAdapter(AdapterBase):
             **kwargs,
         )
 
-    # def handle_batch_transition(self, transitions, sources, **kwargs):
-    #     submissions = sources
-    #     kwargs.pop("source")
-    #     for submission in submissions:
-    #         old_phase = transitions[submission.id]
-    #         return self.handle_transition(
-    #             old_phase=old_phase, source=submission, **kwargs
-    #         )
+    def handle_batch_transition(self, transitions, sources, **kwargs):
+        submissions = sources
+        kwargs.pop("source")
+        for submission in submissions:
+            old_phase = transitions[submission.id]
+            new_phase = submission.phase
+            return self.handle_transition(
+                old_phase=old_phase, new_phase=new_phase, source=submission, **kwargs
+            )
 
     def handle_project_transition(self, source, **kwargs):
         from hypha.apply.projects.models.project import (

--- a/hypha/apply/activity/adapters/slack.py
+++ b/hypha/apply/activity/adapters/slack.py
@@ -49,7 +49,7 @@ class SlackAdapter(AdapterBase):
             "{user} has updated the partners on <{link}|{source.title_text_display}>"
         ),
         MESSAGES.TRANSITION: _(
-            "{user} has updated the status of <{link}|{source.title_text_display}>: {old_phase.display_name} → {source.phase}"
+            "{user} has updated the status of <{link}|{source.title_text_display}>: {source.phase.display_name} → {new_phase.display_name}"
         ),
         MESSAGES.BATCH_TRANSITION: "handle_batch_transition",
         MESSAGES.DETERMINATION_OUTCOME: "handle_determination",

--- a/hypha/apply/activity/templates/messages/email/transition.html
+++ b/hypha/apply/activity/templates/messages/email/transition.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}{# fmt:off #}
-{% blocktrans with old_status=old_phase.public_name new_status=source.phase.public_name %}Your application is now in "{{ new_status }}" status (progressed from "{{ old_status }}").{% endblocktrans %}
+{% blocktrans with new_status=new_phase.public_name old_status=source.phase.public_name %}Your application is now in "{{ new_status }}" status (progressed from "{{ old_status }}").{% endblocktrans %}
 
 {% trans "Please submit any questions related to your application here" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'funds:submissions:comments' pk=source.pk %}
 {% endblock %}{# fmt:on #}

--- a/hypha/apply/activity/templates/messages/email/transition.html
+++ b/hypha/apply/activity/templates/messages/email/transition.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}{# fmt:off #}
-{% blocktrans with new_status=new_phase.public_name old_status=source.phase.public_name %}Your application is now in "{{ new_status }}" status (progressed from "{{ old_status }}").{% endblocktrans %}
+{% blocktrans %}Your application is now in "{{ new_phase }}" status (progressed from "{{ old_phase }}").{% endblocktrans %}
 
 {% trans "Please submit any questions related to your application here" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'funds:submissions:comments' pk=source.pk %}
 {% endblock %}{# fmt:on #}

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -1038,7 +1038,10 @@ class ApplicationSubmission(
     @status_field.on_success()
     def log_status_update(self, descriptor, source, target, **kwargs):
         instance = self
-        old_phase = self.workflow[source]
+
+        # The status associated with the application at this time will be the old phase
+        # so provide the new phase as an arg when transitioning
+        new_phase = self.workflow[target]
 
         by = kwargs["by"]
         request = kwargs["request"]
@@ -1063,7 +1066,7 @@ class ApplicationSubmission(
                     user=by,
                     request=request,
                     source=instance,
-                    related=old_phase,
+                    related=new_phase,
                 )
 
             if instance.status in review_statuses:


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4616. After updating to django-viewflow it looks like the application status doesn't get updated until after the notification is sent, when before this would happen before. Thus, getting the current application status as the "new phase" resulted in a duplicate of the "old phase", ie. `<USER> has updated the status of <APPLICATION>: Need screening → Need screening`

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure slack & email notifications for application transitions represent the actual transition that took place