### PR TITLE
Added ability to create a project in a `Complete` state

### DIFF
--- a/hypha/apply/projects/forms/utils.py
+++ b/hypha/apply/projects/forms/utils.py
@@ -3,7 +3,6 @@ from typing import List, Tuple
 from django.conf import settings
 
 from hypha.apply.projects.models.project import (
-    COMPLETE,
     INTERNAL_APPROVAL,
     PROJECT_STATUS_CHOICES,
 )
@@ -16,9 +15,7 @@ def get_project_status_options() -> List[Tuple[str, str]]:
     being able to set these
     """
     return [
-        status
-        for status in PROJECT_STATUS_CHOICES
-        if status[0] not in [COMPLETE, INTERNAL_APPROVAL]
+        status for status in PROJECT_STATUS_CHOICES if status[0] != INTERNAL_APPROVAL
     ]
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

Staff had requested to create a project in the state of `Completed`. This allows for that

## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure a project can be created with the state of `Complete`