### PR TITLE
Fix invalid end tag in email template

### DIFF
--- a/hypha/apply/activity/templates/messages/email/project_final_approval.html
+++ b/hypha/apply/activity/templates/messages/email/project_final_approval.html
@@ -4,7 +4,7 @@
 {% block salutation %}{% endblock %}
 
 {% block content %}{# fmt:off #}
-{% blocktrans with title=source.title_text_display %}The project "{{title}}" is awaiting final approval.{% blocktrans %}
+{% blocktrans with title=source.title_text_display %}The project "{{title}}" is awaiting final approval.{% endblocktrans %}
 
 {% trans "Approve the project here" %}: {{ request.scheme }}://{{ request.get_host }}{% url 'apply:projects:approval' pk=source.submission.pk %}
 


### PR DESCRIPTION
The `hypha/apply/activity/templates/messages/email/project_final_approval.html` template incorrectly uses `{% blocktrans %}...{% blocktrans %}` instead of `{% blocktrans %}...{% endblocktrans %}`.

I found this while trying to run `makemessages` to generate the translatable strings for our project.