### PR TITLE
Fix display of [View all] button for reviews on submission page

### DIFF
--- a/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
+++ b/hypha/apply/funds/templates/funds/applicationsubmission_admin_detail.html
@@ -42,7 +42,7 @@
             <div class="card-actions">
                 {% include 'review/includes/review_button.html' with submission=object class="grow" %}
 
-                {% if request.user.is_apply_staff and not object.reviews.exists %}
+                {% if request.user.is_apply_staff and object.reviews.exists %}
                     <a
                         href="{% url 'apply:submissions:reviews:list' submission_pk=object.id %}"
                         class="btn btn-outline grow"


### PR DESCRIPTION
After upgrading Hypha to the latest available version, we noticed that the "Reviews & assignees" > [View all] button on the application page (Admin) was missing.

Looking at the commit history, this appears to have changed in 9cfc791538a13aa222c59996666b00ba64ab09af.