### PR TITLE
Fix missing org name (short and long) in email templates

### DIFF
--- a/hypha/apply/activity/adapters/emails.py
+++ b/hypha/apply/activity/adapters/emails.py
@@ -150,11 +150,11 @@ class EmailAdapter(AdapterBase):
             else:
                 try:
                     subject = source.page.specific.subject or _(
-                        "Your application to {org_long_name}: {source.title_text_display}"
-                    ).format(org_long_name=settings.ORG_LONG_NAME, source=source)
+                        "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
+                    ).format(ORG_LONG_NAME=settings.ORG_LONG_NAME, source=source)
                 except AttributeError:
-                    subject = _("Your {org_long_name} Project: {source.title}").format(
-                        org_long_name=settings.ORG_LONG_NAME, source=source
+                    subject = _("Your {ORG_LONG_NAME} Project: {source.title}").format(
+                        ORG_LONG_NAME=settings.ORG_LONG_NAME, source=source
                     )
             return subject
 

--- a/hypha/apply/activity/templates/messages/email/base.html
+++ b/hypha/apply/activity/templates/messages/email/base.html
@@ -6,9 +6,9 @@
 {% block more_info %}{% endblock %}
 
 {# fmt:off #}{% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if ORG_URL %}{{ ORG_URL }}{% endif %}
 {% block post_signature_content %}{% endblock %}{# fmt:on #}

--- a/hypha/apply/funds/workflows/definitions/double_stage.py
+++ b/hypha/apply/funds/workflows/definitions/double_stage.py
@@ -72,8 +72,8 @@ DoubleStageDefinition = [
                 "invited_to_proposal": _("Invite to Proposal"),
             },
             "display": _("Internal Review"),
-            "public": _("{org_short_name} Review").format(
-                org_short_name=settings.ORG_SHORT_NAME
+            "public": _("{ORG_SHORT_NAME} Review").format(
+                ORG_SHORT_NAME=settings.ORG_SHORT_NAME
             ),
             "stage": Concept,
             "permissions": default_permissions,
@@ -209,8 +209,8 @@ DoubleStageDefinition = [
                 "proposal_discussion": _("Proposal Received (revert)"),
             },
             "display": _("Internal Review"),
-            "public": _("{org_short_name} Review").format(
-                org_short_name=settings.ORG_SHORT_NAME
+            "public": _("{ORG_SHORT_NAME} Review").format(
+                ORG_SHORT_NAME=settings.ORG_SHORT_NAME
             ),
             "stage": Proposal,
             "permissions": default_permissions,

--- a/hypha/apply/funds/workflows/definitions/single_stage.py
+++ b/hypha/apply/funds/workflows/definitions/single_stage.py
@@ -72,8 +72,8 @@ SingleStageDefinition = [
                 INITIAL_STATE: _("Need screening (revert)"),
             },
             "display": _("Internal Review"),
-            "public": _("{org_short_name} Review").format(
-                org_short_name=settings.ORG_SHORT_NAME
+            "public": _("{ORG_SHORT_NAME} Review").format(
+                ORG_SHORT_NAME=settings.ORG_SHORT_NAME
             ),
             "stage": Request,
             "permissions": default_permissions,

--- a/hypha/apply/funds/workflows/definitions/single_stage_community.py
+++ b/hypha/apply/funds/workflows/definitions/single_stage_community.py
@@ -81,8 +81,8 @@ SingleStageCommunityDefinition = [
                 "com_rejected": _("Dismiss"),
             },
             "display": _("Internal Review"),
-            "public": _("{org_short_name} Review").format(
-                org_short_name=settings.ORG_SHORT_NAME
+            "public": _("{ORG_SHORT_NAME} Review").format(
+                ORG_SHORT_NAME=settings.ORG_SHORT_NAME
             ),
             "stage": RequestCom,
             "permissions": default_permissions,
@@ -94,8 +94,8 @@ SingleStageCommunityDefinition = [
                 "com_rejected": _("Dismiss"),
             },
             "display": _("Community Review"),
-            "public": _("{org_short_name} Review").format(
-                org_short_name=settings.ORG_SHORT_NAME
+            "public": _("{ORG_SHORT_NAME} Review").format(
+                ORG_SHORT_NAME=settings.ORG_SHORT_NAME
             ),
             "stage": RequestCom,
             "permissions": community_review_permissions,

--- a/hypha/apply/funds/workflows/definitions/single_stage_external.py
+++ b/hypha/apply/funds/workflows/definitions/single_stage_external.py
@@ -67,8 +67,8 @@ SingleStageExternalDefinition = [
                 INITIAL_STATE: _("Need screening (revert)"),
             },
             "display": _("Internal Review"),
-            "public": _("{org_short_name} Review").format(
-                org_short_name=settings.ORG_SHORT_NAME
+            "public": _("{ORG_SHORT_NAME} Review").format(
+                ORG_SHORT_NAME=settings.ORG_SHORT_NAME
             ),
             "stage": RequestExt,
             "permissions": default_permissions,

--- a/hypha/apply/funds/workflows/definitions/single_stage_same.py
+++ b/hypha/apply/funds/workflows/definitions/single_stage_same.py
@@ -67,8 +67,8 @@ SingleStageSameDefinition = [
                 INITIAL_STATE: _("Need screening (revert)"),
             },
             "display": _("Review"),
-            "public": _("{org_short_name} Review").format(
-                org_short_name=settings.ORG_SHORT_NAME
+            "public": _("{ORG_SHORT_NAME} Review").format(
+                ORG_SHORT_NAME=settings.ORG_SHORT_NAME
             ),
             "stage": RequestSame,
             "permissions": reviewer_review_permissions,

--- a/hypha/apply/projects/templatetags/project_tags.py
+++ b/hypha/apply/projects/templatetags/project_tags.py
@@ -123,9 +123,9 @@ def user_next_step_on_project(project, user, request=None):
             return {
                 "heading": _("Waiting for"),
                 "text": _(
-                    "Awaiting project documents to be created and approved by {org_short_name} internally. "
+                    "Awaiting project documents to be created and approved by {ORG_SHORT_NAME} internally. "
                     "Please check back when the project has moved to contracting stage."
-                ).format(org_short_name=settings.ORG_SHORT_NAME),
+                ).format(ORG_SHORT_NAME=settings.ORG_SHORT_NAME),
             }
         if project.paf_approvals.exists():
             return {
@@ -141,9 +141,9 @@ def user_next_step_on_project(project, user, request=None):
             return {
                 "heading": _("Waiting for"),
                 "text": _(
-                    "Awaiting project documents to be created and approved by {org_short_name} internally. "
+                    "Awaiting project documents to be created and approved by {ORG_SHORT_NAME} internally. "
                     "Please check back when the project has moved to contracting stage."
-                ).format(org_short_name=settings.ORG_SHORT_NAME),
+                ).format(ORG_SHORT_NAME=settings.ORG_SHORT_NAME),
             }
 
         if request:
@@ -216,8 +216,8 @@ def user_next_step_on_project(project, user, request=None):
             if user.is_applicant:
                 return {
                     "heading": _("Waiting for"),
-                    "text": _("Awaiting signed contract from {org_short_name}").format(
-                        org_short_name=settings.ORG_SHORT_NAME
+                    "text": _("Awaiting signed contract from {ORG_SHORT_NAME}").format(
+                        ORG_SHORT_NAME=settings.ORG_SHORT_NAME
                     ),
                 }
             if settings.STAFF_UPLOAD_CONTRACT:
@@ -265,8 +265,8 @@ def user_next_step_on_project(project, user, request=None):
                     return {
                         "heading": _("Waiting for"),
                         "text": _(
-                            "Awaiting contract approval from {org_short_name}"
-                        ).format(org_short_name=settings.ORG_SHORT_NAME),
+                            "Awaiting contract approval from {ORG_SHORT_NAME}"
+                        ).format(ORG_SHORT_NAME=settings.ORG_SHORT_NAME),
                     }
                 return {
                     "heading": _("Waiting for"),
@@ -300,8 +300,8 @@ def user_next_step_instructions(project, user):
         if contract and not contract.signed_by_applicant:
             return [
                 _(
-                    "Please download the signed contract uploaded by {org_short_name}"
-                ).format(org_short_name=settings.ORG_SHORT_NAME),
+                    "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
+                ).format(ORG_SHORT_NAME=settings.ORG_SHORT_NAME),
                 _("Countersign"),
                 _("Upload it back"),
                 _(

--- a/hypha/apply/users/services.py
+++ b/hypha/apply/users/services.py
@@ -94,15 +94,15 @@ class PasswordlessAuthService:
 
     def get_email_context(self) -> dict:
         return {
-            "org_long_name": settings.ORG_LONG_NAME,
-            "org_email": settings.ORG_EMAIL,
-            "org_short_name": settings.ORG_SHORT_NAME,
+            "ORG_LONG_NAME": settings.ORG_LONG_NAME,
+            "ORG_EMAIL": settings.ORG_EMAIL,
+            "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
             "site": self.site,
         }
 
     def send_email_no_account_found(self, to):
         context = self.get_email_context()
-        subject = "Log in attempt at {org_long_name}".format(**context)
+        subject = "Log in attempt at {ORG_LONG_NAME}".format(**context)
         # Force subject to a single line to avoid header-injection issues.
         subject = "".join(subject.splitlines())
 
@@ -130,7 +130,7 @@ class PasswordlessAuthService:
             }
         )
 
-        subject = "Log in to {username} at {org_long_name}".format(**context)
+        subject = "Log in to {username} at {ORG_LONG_NAME}".format(**context)
         # Force subject to a single line to avoid header-injection issues.
         subject = "".join(subject.splitlines())
 
@@ -154,7 +154,7 @@ class PasswordlessAuthService:
             }
         )
 
-        subject = "Welcome to {org_long_name}".format(**context)
+        subject = "Welcome to {ORG_LONG_NAME}".format(**context)
         # Force subject to a single line to avoid header-injection issues.
         subject = "".join(subject.splitlines())
 

--- a/hypha/apply/users/templates/users/activation/email.txt
+++ b/hypha/apply/users/templates/users/activation/email.txt
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}{% firstof name username as user %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 
-{% blocktrans %}Activate your account on the {{ org_long_name }} web site by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
+{% blocktrans %}Activate your account on the {{ ORG_LONG_NAME }} web site by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
 
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{{ activation_path }}
 
@@ -15,8 +15,8 @@
 {% blocktrans %}If you do not complete the activation process within {{ timeout_days }} days you can use the password reset form at{% endblocktrans %}: {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{% url 'users:password_reset' %}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 -- 
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/activation/email_subject.txt
+++ b/hypha/apply/users/templates/users/activation/email_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% blocktranslate %}Account details for {{ username }} at {{ org_long_name }}{% endblocktranslate %}
+{% blocktranslate %}Account details for {{ username }} at {{ ORG_LONG_NAME }}{% endblocktranslate %}
 {% endautoescape %}

--- a/hypha/apply/users/templates/users/email_change/confirm_email.txt
+++ b/hypha/apply/users/templates/users/email_change/confirm_email.txt
@@ -1,15 +1,15 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}{% firstof name username as user %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 
-{% blocktrans %}Request to change email of your account on the {{ org_long_name }} web site has been accepted. Confirm your email by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
+{% blocktrans %}Request to change email of your account on the {{ ORG_LONG_NAME }} web site has been accepted. Confirm your email by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
 
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{{ activation_path }}
 
 {% blocktrans %}This link will only remain active for {{ timeout_days }} days and will lead you to profile page after verification.{% endblocktrans %}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/email_change/update_info_email.html
+++ b/hypha/apply/users/templates/users/email_change/update_info_email.html
@@ -1,12 +1,12 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}{% firstof name username as user %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 
-{% blocktrans %}There has been an attempt to change email of your account on the {{ org_long_name }} web site. If this action wasn't made by you, please contact support at {{ org_email }} {% endblocktrans %}
+{% blocktrans %}There has been an attempt to change email of your account on the {{ ORG_LONG_NAME }} web site. If this action wasn't made by you, please contact support at {{ ORG_EMAIL }} {% endblocktrans %}
 
 
 {# fmt:off #}{% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{# fmt:on #}

--- a/hypha/apply/users/templates/users/emails/confirm_access.md
+++ b/hypha/apply/users/templates/users/emails/confirm_access.md
@@ -1,19 +1,19 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 
-{% blocktrans %}To confirm access at {{ org_long_name }} use the code below (valid for {{ timeout_minutes }} minutes):{% endblocktrans %}
+{% blocktrans %}To confirm access at {{ ORG_LONG_NAME }} use the code below (valid for {{ timeout_minutes }} minutes):{% endblocktrans %}
 
 {{ token }}
 
 {% blocktrans %}If you did not request this email, please ignore it.{% endblocktrans %}
 
-{% if org_email %}
-{% blocktrans %}If you have any questions, please contact us at {{ org_email }}.{% endblocktrans %}
+{% if ORG_EMAIL %}
+{% blocktrans %}If you have any questions, please contact us at {{ ORG_EMAIL }}.{% endblocktrans %}
 {% endif %}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/emails/passwordless_login_email.md
+++ b/hypha/apply/users/templates/users/emails/passwordless_login_email.md
@@ -2,25 +2,25 @@
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 
 {% if is_active %}
-{% blocktrans %}Login to your account on the {{ org_long_name }} web site by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
+{% blocktrans %}Login to your account on the {{ ORG_LONG_NAME }} web site by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
 
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{{ login_path }}
 
 {% blocktrans %}This link will valid for {{ timeout_minutes }} minutes and can be used only once.{% endblocktrans %}
 
 {% else %}
-{% blocktrans %}Your account on the {{ org_long_name }} web site is deactivated. Please contact site administrators.{% endblocktrans %}
+{% blocktrans %}Your account on the {{ ORG_LONG_NAME }} web site is deactivated. Please contact site administrators.{% endblocktrans %}
 {% endif %}
 
 {% blocktrans %}If you did not request this email, please ignore it.{% endblocktrans %}
 
-{% if org_email %}
-{% blocktrans %}If you have any questions, please contact us at {{ org_email }}.{% endblocktrans %}
+{% if ORG_EMAIL %}
+{% blocktrans %}If you have any questions, please contact us at {{ ORG_EMAIL }}.{% endblocktrans %}
 {% endif %}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md
+++ b/hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md
@@ -2,15 +2,15 @@
 
 {% blocktrans %}Dear,{% endblocktrans %}
 
-{% blocktrans %}It looks like you are trying to login on {{ org_long_name }} web site, but we could not find any account with the email provided.{% endblocktrans %}
+{% blocktrans %}It looks like you are trying to login on {{ ORG_LONG_NAME }} web site, but we could not find any account with the email provided.{% endblocktrans %}
 
-{% if org_email %}
-{% blocktrans %}If you have any questions, please contact us at {{ org_email }}.{% endblocktrans %}
+{% if ORG_EMAIL %}
+{% blocktrans %}If you have any questions, please contact us at {{ ORG_EMAIL }}.{% endblocktrans %}
 {% endif %}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/emails/passwordless_new_account_login.md
+++ b/hypha/apply/users/templates/users/emails/passwordless_new_account_login.md
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
 {% blocktrans %}Dear,{% endblocktrans %}
 
-{% blocktrans %}Welcome to {{ org_long_name }} web site. Create your account by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
+{% blocktrans %}Welcome to {{ ORG_LONG_NAME }} web site. Create your account by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
 
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{{ signup_path }}
 
@@ -9,13 +9,13 @@
 
 {% blocktrans %}If you did not request this email, please ignore it.{% endblocktrans %}
 
-{% if org_email %}
-{% blocktrans %}If you have any questions, please contact us at {{ org_email }}.{% endblocktrans %}
+{% if ORG_EMAIL %}
+{% blocktrans %}If you have any questions, please contact us at {{ ORG_EMAIL }}.{% endblocktrans %}
 {% endif %}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/emails/set_password.txt
+++ b/hypha/apply/users/templates/users/emails/set_password.txt
@@ -1,15 +1,15 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}{% firstof name username as user %}
 {% blocktrans %}Dear {{ user }},{% endblocktrans %}
 
-{% blocktrans %}Set your account password on the {{ org_long_name }} web site by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
+{% blocktrans %}Set your account password on the {{ ORG_LONG_NAME }} web site by clicking this link or copying and pasting it to your browser:{% endblocktrans %}
 
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}{{ activation_path }}
 
 {% blocktrans %}This link can be used only once and will lead you to a page where you can set your password. It will remain active for {{ timeout_days }} days, so please set your password as soon as possible.{% endblocktrans %}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/emails/set_password_subject.txt
+++ b/hypha/apply/users/templates/users/emails/set_password_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}{% autoescape off %}
-{% blocktranslate %}Set password for {{ username }} at {{ org_long_name }}{% endblocktranslate %}
+{% blocktranslate %}Set password for {{ username }} at {{ ORG_LONG_NAME }}{% endblocktranslate %}
 {% endautoescape %}

--- a/hypha/apply/users/templates/users/password_reset/email.txt
+++ b/hypha/apply/users/templates/users/password_reset/email.txt
@@ -1,15 +1,15 @@
 {% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
 {% blocktranslate %}Dear {{ user }},{% endblocktranslate %}
 
-{% blocktranslate %}You're receiving this email because you requested a password reset for your user account at {{ org_long_name }}.{% endblocktranslate %}
+{% blocktranslate %}You're receiving this email because you requested a password reset for your user account at {{ ORG_LONG_NAME }}.{% endblocktranslate %}
 
 {% trans "Please follow the link below to reset your password:" %}
 
 {{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}{% if redirect_url %}?next={{ redirect_url }}{% endif%}
 
 {% blocktrans %}Kind Regards,
-The {{ org_short_name }} Team{% endblocktrans %}
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
 
 --
-{{ org_long_name }}
+{{ ORG_LONG_NAME }}
 {% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/utils.py
+++ b/hypha/apply/users/utils.py
@@ -85,8 +85,8 @@ def send_activation_email(
         "username": user.get_username(),
         "activation_path": activation_path,
         "timeout_days": timeout_days,
-        "org_long_name": settings.ORG_LONG_NAME,
-        "org_short_name": settings.ORG_SHORT_NAME,
+        "ORG_LONG_NAME": settings.ORG_LONG_NAME,
+        "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
     }
 
     if site:
@@ -120,14 +120,14 @@ def send_confirmation_email(user, token, updated_email=None, site=None):
         "unverified_email": updated_email,
         "activation_path": activation_path,
         "timeout_days": timeout_days,
-        "org_long_name": settings.ORG_LONG_NAME,
-        "org_short_name": settings.ORG_SHORT_NAME,
+        "ORG_LONG_NAME": settings.ORG_LONG_NAME,
+        "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
     }
 
     if site:
         context.update(site=site)
 
-    subject = "Confirmation email for {unverified_email} at {org_long_name}".format(
+    subject = "Confirmation email for {unverified_email} at {ORG_LONG_NAME}".format(
         **context
     )
     # Force subject to a single line to avoid header-injection issues.

--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -213,9 +213,9 @@ def account_email_change(request):
             {
                 "name": request.user.get_full_name(),
                 "username": request.user.get_username(),
-                "org_email": settings.ORG_EMAIL,
-                "org_short_name": settings.ORG_SHORT_NAME,
-                "org_long_name": settings.ORG_LONG_NAME,
+                "ORG_EMAIL": settings.ORG_EMAIL,
+                "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
+                "ORG_LONG_NAME": settings.ORG_LONG_NAME,
             },
         ),
         from_email=settings.DEFAULT_FROM_EMAIL,
@@ -393,8 +393,8 @@ class PasswordResetView(DjPasswordResetView):
         return {
             "redirect_url": get_redirect_url(self.request, self.redirect_field_name),
             "site": Site.find_for_request(self.request),
-            "org_short_name": settings.ORG_SHORT_NAME,
-            "org_long_name": settings.ORG_LONG_NAME,
+            "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
+            "ORG_LONG_NAME": settings.ORG_LONG_NAME,
         }
 
     def form_valid(self, form):
@@ -728,16 +728,16 @@ def send_confirm_access_email_view(request):
         user=request.user, token=generate_numeric_token
     )
     email_context = {
-        "org_long_name": settings.ORG_LONG_NAME,
-        "org_email": settings.ORG_EMAIL,
-        "org_short_name": settings.ORG_SHORT_NAME,
+        "ORG_LONG_NAME": settings.ORG_LONG_NAME,
+        "ORG_EMAIL": settings.ORG_EMAIL,
+        "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
         "token": token_obj.token,
         "username": request.user.email,
         "site": Site.find_for_request(request),
         "user": request.user,
         "timeout_minutes": settings.PASSWORDLESS_LOGIN_TIMEOUT // 60,
     }
-    subject = "Confirmation code for {org_long_name}: {token}".format(**email_context)
+    subject = "Confirmation code for {ORG_LONG_NAME}: {token}".format(**email_context)
     email = MarkdownMail("users/emails/confirm_access.md")
     email.send(
         to=request.user.email,

--- a/hypha/locale/cs/LC_MESSAGES/django.po
+++ b/hypha/locale/cs/LC_MESSAGES/django.po
@@ -1254,6 +1254,7 @@ msgid "Dear %(user)s,"
 msgstr "Vážený %(user)s,"
 
 #: hypha/apply/activity/templates/messages/email/base.html:8
+#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
@@ -7300,15 +7301,6 @@ msgstr ""
 "Na webových stránkách %(ORG_LONG_NAME)s došlo k pokusu o změnu e-mailu "
 "vašeho účtu.Pokud jste tuto akci neprovedli vy, kontaktujte prosím podporu "
 "na adrese %(ORG_EMAIL)s. "
-
-#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
-#, python-format
-msgid ""
-"Kind Regards,\n"
-"    The %(ORG_SHORT_NAME)s Team"
-msgstr ""
-"S laskavým pozdravem,\n"
-"    Tým %(ORG_SHORT_NAME)s"
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format

--- a/hypha/locale/cs/LC_MESSAGES/django.po
+++ b/hypha/locale/cs/LC_MESSAGES/django.po
@@ -297,13 +297,13 @@ msgstr "Projektová dokumentace je připravena ke schválení: {source.title}"
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, python-brace-format
-msgid "Your application to {org_long_name}: {source.title_text_display}"
-msgstr "Vaše žádost na {org_long_name}: {source.title_text_display}"
+msgid "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
+msgstr "Vaše žádost na {ORG_LONG_NAME}: {source.title_text_display}"
 
 #: hypha/apply/activity/adapters/emails.py:140
 #, python-brace-format
-msgid "Your {org_long_name} Project: {source.title}"
-msgstr "Vaše {org_long_name} Projekt: {source.title}"
+msgid "Your {ORG_LONG_NAME} Project: {source.title}"
+msgstr "Vaše {ORG_LONG_NAME} Projekt: {source.title}"
 
 #: hypha/apply/activity/adapters/slack.py:31
 #, python-brace-format
@@ -4377,8 +4377,8 @@ msgstr "Vyžaduje screening (vrátit)"
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:70
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:70
 #, python-brace-format
-msgid "{org_short_name} Review"
-msgstr "Hodnocení {org_short_name}"
+msgid "{ORG_SHORT_NAME} Review"
+msgstr "Hodnocení {ORG_SHORT_NAME}"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:87
 #: hypha/apply/funds/workflows/definitions/single_stage.py:87
@@ -5850,12 +5850,12 @@ msgstr "Čekání na"
 #: hypha/apply/projects/templatetags/project_tags.py:83
 #, python-brace-format
 msgid ""
-"Awaiting project documents to be created and approved by {org_short_name} "
+"Awaiting project documents to be created and approved by {ORG_SHORT_NAME} "
 "internally. Please check back when the project has moved to contracting "
 "stage."
 msgstr ""
 "Čeká se na vytvoření projektové dokumentace, kterou interně schválí "
-"{org_short_name}.Zkontrolujte prosím, až projekt přejde do fáze uzavírání "
+"{ORG_SHORT_NAME}.Zkontrolujte prosím, až projekt přejde do fáze uzavírání "
 "smluv."
 
 #: hypha/apply/projects/templatetags/project_tags.py:72
@@ -5892,8 +5892,8 @@ msgstr "Čeká se na projekt od přiřazených schvalovatelů"
 
 #: hypha/apply/projects/templatetags/project_tags.py:158
 #, python-brace-format
-msgid "Awaiting signed contract from {org_short_name}"
-msgstr "Čeká se na podepsanou smlouvu od {org_short_name}"
+msgid "Awaiting signed contract from {ORG_SHORT_NAME}"
+msgstr "Čeká se na podepsanou smlouvu od {ORG_SHORT_NAME}"
 
 #: hypha/apply/projects/templatetags/project_tags.py:165
 msgid "Awaiting signed contract from Staff/Contracting team"
@@ -5927,8 +5927,8 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:207
 #, python-brace-format
-msgid "Awaiting contract approval from {org_short_name}"
-msgstr "Čeká se na schválení smlouvy od {org_short_name}"
+msgid "Awaiting contract approval from {ORG_SHORT_NAME}"
+msgstr "Čeká se na schválení smlouvy od {ORG_SHORT_NAME}"
 
 #: hypha/apply/projects/templatetags/project_tags.py:212
 msgid "Awaiting contract approval from Staff"
@@ -5944,8 +5944,8 @@ msgstr "Zkontrolujte fakturu a přijměte opatření"
 
 #: hypha/apply/projects/templatetags/project_tags.py:242
 #, python-brace-format
-msgid "Please download the signed contract uploaded by {org_short_name}"
-msgstr "Stáhněte si podepsanou smlouvu nahranou od {org_short_name}"
+msgid "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
+msgstr "Stáhněte si podepsanou smlouvu nahranou od {ORG_SHORT_NAME}"
 
 #: hypha/apply/projects/templatetags/project_tags.py:244
 msgid "Countersign"
@@ -7102,10 +7102,10 @@ msgstr "Zapnout 2FA"
 #: hypha/apply/users/templates/users/activation/email.txt:4
 #, python-format
 msgid ""
-"Activate your account on the %(org_long_name)s web site by clicking this "
+"Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Aktivujte si účet na webových stránkách %(org_long_name)s kliknutím na tento "
+"Aktivujte si účet na webových stránkách %(ORG_LONG_NAME)s kliknutím na tento "
 "odkaz nebo jeho zkopírováním a vložením do prohlížeče:"
 
 #: hypha/apply/users/templates/users/activation/email.txt:8
@@ -7156,15 +7156,15 @@ msgstr ""
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"The %(org_short_name)s Team"
+"The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 "S laskavým pozdravem,\n"
-"Tým %(org_short_name)s"
+"Tým %(ORG_SHORT_NAME)s"
 
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
-msgid "Account details for %(username)s at %(org_long_name)s"
-msgstr "Údaje o účtu %(username)s u %(org_long_name)s"
+msgid "Account details for %(username)s at %(ORG_LONG_NAME)s"
+msgstr "Údaje o účtu %(username)s u %(ORG_LONG_NAME)s"
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
 msgid "Invalid activation"
@@ -7219,11 +7219,11 @@ msgstr "Zpět na účet"
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
 msgid ""
-"Request to change email of your account on the %(org_long_name)s web site "
+"Request to change email of your account on the %(ORG_LONG_NAME)s web site "
 "has been accepted. Confirm your email by clicking this link or copying and "
 "pasting it to your browser:"
 msgstr ""
-"Žádost o změnu e-mailu vašeho účtu na webových stránkách %(org_long_name)s "
+"Žádost o změnu e-mailu vašeho účtu na webových stránkách %(ORG_LONG_NAME)s "
 "byla přijata. Potvrďte svůj e-mail kliknutím na tento odkaz nebo jeho "
 "zkopírováním a vložením do prohlížeče:"
 
@@ -7294,29 +7294,29 @@ msgstr ""
 #, python-format
 msgid ""
 "There has been an attempt to change email of your account on the "
-"%(org_long_name)s web site. If this action wasn't made by you, please "
-"contact support at %(org_email)s "
+"%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
+"contact support at %(ORG_EMAIL)s "
 msgstr ""
-"Na webových stránkách %(org_long_name)s došlo k pokusu o změnu e-mailu "
+"Na webových stránkách %(ORG_LONG_NAME)s došlo k pokusu o změnu e-mailu "
 "vašeho účtu.Pokud jste tuto akci neprovedli vy, kontaktujte prosím podporu "
-"na adrese %(org_email)s. "
+"na adrese %(ORG_EMAIL)s. "
 
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"    The %(org_short_name)s Team"
+"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 "S laskavým pozdravem,\n"
-"    Tým %(org_short_name)s"
+"    Tým %(ORG_SHORT_NAME)s"
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format
 msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
+"To confirm access at %(ORG_LONG_NAME)s use the code below (valid for "
 "%(timeout_minutes)s minutes):"
 msgstr ""
-"Pro potvrzení přístupu na %(org_long_name)s použijte níže uvedený kód ("
+"Pro potvrzení přístupu na %(ORG_LONG_NAME)s použijte níže uvedený kód ("
 "platný po dobu %(timeout_minutes)s minut):"
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:8
@@ -7330,16 +7330,16 @@ msgstr "Pokud jste si tento e-mail nevyžádali, ignorujte jej."
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:8
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
 #, python-format
-msgid "If you have any questions, please contact us at %(org_email)s."
-msgstr "V případě jakýchkoli dotazů nás prosím kontaktujte na %(org_email)s."
+msgid "If you have any questions, please contact us at %(ORG_EMAIL)s."
+msgstr "V případě jakýchkoli dotazů nás prosím kontaktujte na %(ORG_EMAIL)s."
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
 #, python-format
 msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
+"Login to your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Přihlaste se ke svému účtu na webu %(org_long_name)s kliknutím na tento "
+"Přihlaste se ke svému účtu na webu %(ORG_LONG_NAME)s kliknutím na tento "
 "odkaz nebo jeho zkopírováním a vložením do prohlížeče:"
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:9
@@ -7355,10 +7355,10 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
 #, python-format
 msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
+"Your account on the %(ORG_LONG_NAME)s web site is deactivated. Please "
 "contact site administrators."
 msgstr ""
-"Váš účet na webu %(org_long_name)s je deaktivován. Kontaktujte prosím "
+"Váš účet na webu %(ORG_LONG_NAME)s je deaktivován. Kontaktujte prosím "
 "správce stránek."
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:3
@@ -7369,34 +7369,34 @@ msgstr "Vážený,"
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
 #, python-format
 msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
+"It looks like you are trying to login on %(ORG_LONG_NAME)s web site, but we "
 "could not find any account with the email provided."
 msgstr ""
-"Vypadá to, že se snažíte přihlásit na webové stránky %(org_long_name)s, ale "
+"Vypadá to, že se snažíte přihlásit na webové stránky %(ORG_LONG_NAME)s, ale "
 "nepodařilo se nám najít žádný účet se zadaným e-mailem."
 
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
 #, python-format
 msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
+"Welcome to %(ORG_LONG_NAME)s web site. Create your account by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Vítejte na stránkách %(org_long_name)s. Vytvořte si účet kliknutím na tento "
+"Vítejte na stránkách %(ORG_LONG_NAME)s. Vytvořte si účet kliknutím na tento "
 "odkaz nebo jeho zkopírováním a vložením do prohlížeče:"
 
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, python-format
 msgid ""
-"Set your account password on the %(org_long_name)s web site by clicking this "
+"Set your account password on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Heslo k účtu nastavíte na webu %(org_long_name)s kliknutím na tento odkaz "
+"Heslo k účtu nastavíte na webu %(ORG_LONG_NAME)s kliknutím na tento odkaz "
 "nebo jeho zkopírováním a vložením do prohlížeče:"
 
 #: hypha/apply/users/templates/users/emails/set_password_subject.txt:2
 #, python-format
-msgid "Set password for %(username)s at %(org_long_name)s"
-msgstr "Nastavte heslo pro %(username)s na %(org_long_name)s"
+msgid "Set password for %(username)s at %(ORG_LONG_NAME)s"
+msgstr "Nastavte heslo pro %(username)s na %(ORG_LONG_NAME)s"
 
 #: hypha/apply/users/templates/users/login.html:20
 #: hypha/apply/users/templates/users/login.html:24
@@ -7576,10 +7576,10 @@ msgstr ""
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(org_long_name)s."
+"user account at %(ORG_LONG_NAME)s."
 msgstr ""
 "Tento e-mail jste obdrželi, protože jste požádali o obnovení hesla ke svému "
-"uživatelskému účtu na %(org_long_name)s."
+"uživatelskému účtu na %(ORG_LONG_NAME)s."
 
 #: hypha/apply/users/templates/users/password_reset/email.txt:6
 msgid "Please follow the link below to reset your password:"
@@ -8237,8 +8237,8 @@ msgstr "Pro pokračování zadejte heslo."
 #~ "Opravdu chcete tuto úlohu odebrat? Odstraní tuto úlohu ze seznamu úloh."
 
 #, python-brace-format
-#~ msgid "Confirmation code for {org_long_name}: {token}"
-#~ msgstr "Potvrzovací kód pro {org_long_name}:{token}"
+#~ msgid "Confirmation code for {ORG_LONG_NAME}: {token}"
+#~ msgstr "Potvrzovací kód pro {ORG_LONG_NAME}:{token}"
 
 #~ msgid "Submit for Approval"
 #~ msgstr "Předložit ke schválení"

--- a/hypha/locale/django.pot
+++ b/hypha/locale/django.pot
@@ -287,12 +287,12 @@ msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, python-brace-format
-msgid "Your application to {org_long_name}: {source.title_text_display}"
+msgid "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:140
 #, python-brace-format
-msgid "Your {org_long_name} Project: {source.title}"
+msgid "Your {ORG_LONG_NAME} Project: {source.title}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/slack.py:31
@@ -4230,7 +4230,7 @@ msgstr ""
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:70
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:70
 #, python-brace-format
-msgid "{org_short_name} Review"
+msgid "{ORG_SHORT_NAME} Review"
 msgstr ""
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:87
@@ -5663,7 +5663,7 @@ msgstr ""
 #: hypha/apply/projects/templatetags/project_tags.py:83
 #, python-brace-format
 msgid ""
-"Awaiting project documents to be created and approved by {org_short_name} "
+"Awaiting project documents to be created and approved by {ORG_SHORT_NAME} "
 "internally. Please check back when the project has moved to contracting "
 "stage."
 msgstr ""
@@ -5702,7 +5702,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:158
 #, python-brace-format
-msgid "Awaiting signed contract from {org_short_name}"
+msgid "Awaiting signed contract from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:165
@@ -5735,7 +5735,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:207
 #, python-brace-format
-msgid "Awaiting contract approval from {org_short_name}"
+msgid "Awaiting contract approval from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:212
@@ -5752,7 +5752,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:242
 #, python-brace-format
-msgid "Please download the signed contract uploaded by {org_short_name}"
+msgid "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:244
@@ -6778,7 +6778,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/activation/email.txt:4
 #, python-format
 msgid ""
-"Activate your account on the %(org_long_name)s web site by clicking this "
+"Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -6825,12 +6825,12 @@ msgstr ""
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"The %(org_short_name)s Team"
+"The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
-msgid "Account details for %(username)s at %(org_long_name)s"
+msgid "Account details for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
@@ -6884,7 +6884,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
 msgid ""
-"Request to change email of your account on the %(org_long_name)s web site "
+"Request to change email of your account on the %(ORG_LONG_NAME)s web site "
 "has been accepted. Confirm your email by clicking this link or copying and "
 "pasting it to your browser:"
 msgstr ""
@@ -6950,21 +6950,21 @@ msgstr ""
 #, python-format
 msgid ""
 "There has been an attempt to change email of your account on the "
-"%(org_long_name)s web site. If this action wasn't made by you, please "
-"contact support at %(org_email)s "
+"%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
+"contact support at %(ORG_EMAIL)s "
 msgstr ""
 
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"    The %(org_short_name)s Team"
+"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format
 msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
+"To confirm access at %(ORG_LONG_NAME)s use the code below (valid for "
 "%(timeout_minutes)s minutes):"
 msgstr ""
 
@@ -6979,13 +6979,13 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:8
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
 #, python-format
-msgid "If you have any questions, please contact us at %(org_email)s."
+msgid "If you have any questions, please contact us at %(ORG_EMAIL)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
 #, python-format
 msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
+"Login to your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
 #, python-format
 msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
+"Your account on the %(ORG_LONG_NAME)s web site is deactivated. Please "
 "contact site administrators."
 msgstr ""
 
@@ -7012,27 +7012,27 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
 #, python-format
 msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
+"It looks like you are trying to login on %(ORG_LONG_NAME)s web site, but we "
 "could not find any account with the email provided."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
 #, python-format
 msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
+"Welcome to %(ORG_LONG_NAME)s web site. Create your account by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, python-format
 msgid ""
-"Set your account password on the %(org_long_name)s web site by clicking this "
+"Set your account password on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password_subject.txt:2
 #, python-format
-msgid "Set password for %(username)s at %(org_long_name)s"
+msgid "Set password for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/login.html:20
@@ -7197,7 +7197,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(org_long_name)s."
+"user account at %(ORG_LONG_NAME)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/password_reset/email.txt:6

--- a/hypha/locale/en/LC_MESSAGES/django.po
+++ b/hypha/locale/en/LC_MESSAGES/django.po
@@ -287,12 +287,12 @@ msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, python-brace-format
-msgid "Your application to {org_long_name}: {source.title_text_display}"
+msgid "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:140
 #, python-brace-format
-msgid "Your {org_long_name} Project: {source.title}"
+msgid "Your {ORG_LONG_NAME} Project: {source.title}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/slack.py:31
@@ -4230,7 +4230,7 @@ msgstr ""
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:70
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:70
 #, python-brace-format
-msgid "{org_short_name} Review"
+msgid "{ORG_SHORT_NAME} Review"
 msgstr ""
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:87
@@ -5663,7 +5663,7 @@ msgstr ""
 #: hypha/apply/projects/templatetags/project_tags.py:83
 #, python-brace-format
 msgid ""
-"Awaiting project documents to be created and approved by {org_short_name} "
+"Awaiting project documents to be created and approved by {ORG_SHORT_NAME} "
 "internally. Please check back when the project has moved to contracting "
 "stage."
 msgstr ""
@@ -5702,7 +5702,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:158
 #, python-brace-format
-msgid "Awaiting signed contract from {org_short_name}"
+msgid "Awaiting signed contract from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:165
@@ -5735,7 +5735,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:207
 #, python-brace-format
-msgid "Awaiting contract approval from {org_short_name}"
+msgid "Awaiting contract approval from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:212
@@ -5752,7 +5752,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:242
 #, python-brace-format
-msgid "Please download the signed contract uploaded by {org_short_name}"
+msgid "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:244
@@ -6778,7 +6778,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/activation/email.txt:4
 #, python-format
 msgid ""
-"Activate your account on the %(org_long_name)s web site by clicking this "
+"Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -6825,12 +6825,12 @@ msgstr ""
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"The %(org_short_name)s Team"
+"The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
-msgid "Account details for %(username)s at %(org_long_name)s"
+msgid "Account details for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
@@ -6884,7 +6884,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
 msgid ""
-"Request to change email of your account on the %(org_long_name)s web site "
+"Request to change email of your account on the %(ORG_LONG_NAME)s web site "
 "has been accepted. Confirm your email by clicking this link or copying and "
 "pasting it to your browser:"
 msgstr ""
@@ -6950,21 +6950,21 @@ msgstr ""
 #, python-format
 msgid ""
 "There has been an attempt to change email of your account on the "
-"%(org_long_name)s web site. If this action wasn't made by you, please "
-"contact support at %(org_email)s "
+"%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
+"contact support at %(ORG_EMAIL)s "
 msgstr ""
 
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"    The %(org_short_name)s Team"
+"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format
 msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
+"To confirm access at %(ORG_LONG_NAME)s use the code below (valid for "
 "%(timeout_minutes)s minutes):"
 msgstr ""
 
@@ -6979,13 +6979,13 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:8
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
 #, python-format
-msgid "If you have any questions, please contact us at %(org_email)s."
+msgid "If you have any questions, please contact us at %(ORG_EMAIL)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
 #, python-format
 msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
+"Login to your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -7000,7 +7000,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
 #, python-format
 msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
+"Your account on the %(ORG_LONG_NAME)s web site is deactivated. Please "
 "contact site administrators."
 msgstr ""
 
@@ -7012,27 +7012,27 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
 #, python-format
 msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
+"It looks like you are trying to login on %(ORG_LONG_NAME)s web site, but we "
 "could not find any account with the email provided."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
 #, python-format
 msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
+"Welcome to %(ORG_LONG_NAME)s web site. Create your account by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, python-format
 msgid ""
-"Set your account password on the %(org_long_name)s web site by clicking this "
+"Set your account password on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password_subject.txt:2
 #, python-format
-msgid "Set password for %(username)s at %(org_long_name)s"
+msgid "Set password for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/login.html:20
@@ -7197,7 +7197,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(org_long_name)s."
+"user account at %(ORG_LONG_NAME)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/password_reset/email.txt:6

--- a/hypha/locale/en/LC_MESSAGES/django.po
+++ b/hypha/locale/en/LC_MESSAGES/django.po
@@ -1197,6 +1197,7 @@ msgid "Dear %(user)s,"
 msgstr ""
 
 #: hypha/apply/activity/templates/messages/email/base.html:8
+#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
@@ -6952,13 +6953,6 @@ msgid ""
 "There has been an attempt to change email of your account on the "
 "%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
 "contact support at %(ORG_EMAIL)s "
-msgstr ""
-
-#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
-#, python-format
-msgid ""
-"Kind Regards,\n"
-"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4

--- a/hypha/locale/es/LC_MESSAGES/django.po
+++ b/hypha/locale/es/LC_MESSAGES/django.po
@@ -1250,6 +1250,7 @@ msgid "Dear %(user)s,"
 msgstr ""
 
 #: hypha/apply/activity/templates/messages/email/base.html:8
+#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
@@ -7119,13 +7120,6 @@ msgid ""
 "There has been an attempt to change email of your account on the "
 "%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
 "contact support at %(ORG_EMAIL)s "
-msgstr ""
-
-#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
-#, python-format
-msgid ""
-"Kind Regards,\n"
-"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4

--- a/hypha/locale/es/LC_MESSAGES/django.po
+++ b/hypha/locale/es/LC_MESSAGES/django.po
@@ -304,12 +304,12 @@ msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, python-brace-format
-msgid "Your application to {org_long_name}: {source.title_text_display}"
+msgid "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:140
 #, python-brace-format
-msgid "Your {org_long_name} Project: {source.title}"
+msgid "Your {ORG_LONG_NAME} Project: {source.title}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/slack.py:31
@@ -4307,7 +4307,7 @@ msgstr ""
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:70
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:70
 #, python-brace-format
-msgid "{org_short_name} Review"
+msgid "{ORG_SHORT_NAME} Review"
 msgstr ""
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:87
@@ -5818,7 +5818,7 @@ msgstr ""
 #: hypha/apply/projects/templatetags/project_tags.py:83
 #, python-brace-format
 msgid ""
-"Awaiting project documents to be created and approved by {org_short_name} "
+"Awaiting project documents to be created and approved by {ORG_SHORT_NAME} "
 "internally. Please check back when the project has moved to contracting "
 "stage."
 msgstr ""
@@ -5857,7 +5857,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:158
 #, python-brace-format
-msgid "Awaiting signed contract from {org_short_name}"
+msgid "Awaiting signed contract from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:165
@@ -5890,7 +5890,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:207
 #, python-brace-format
-msgid "Awaiting contract approval from {org_short_name}"
+msgid "Awaiting contract approval from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:212
@@ -5907,7 +5907,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:242
 #, python-brace-format
-msgid "Please download the signed contract uploaded by {org_short_name}"
+msgid "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:244
@@ -6945,7 +6945,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/activation/email.txt:4
 #, python-format
 msgid ""
-"Activate your account on the %(org_long_name)s web site by clicking this "
+"Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -6992,12 +6992,12 @@ msgstr ""
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"The %(org_short_name)s Team"
+"The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
-msgid "Account details for %(username)s at %(org_long_name)s"
+msgid "Account details for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
@@ -7051,7 +7051,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
 msgid ""
-"Request to change email of your account on the %(org_long_name)s web site "
+"Request to change email of your account on the %(ORG_LONG_NAME)s web site "
 "has been accepted. Confirm your email by clicking this link or copying and "
 "pasting it to your browser:"
 msgstr ""
@@ -7117,21 +7117,21 @@ msgstr ""
 #, python-format
 msgid ""
 "There has been an attempt to change email of your account on the "
-"%(org_long_name)s web site. If this action wasn't made by you, please "
-"contact support at %(org_email)s "
+"%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
+"contact support at %(ORG_EMAIL)s "
 msgstr ""
 
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"    The %(org_short_name)s Team"
+"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format
 msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
+"To confirm access at %(ORG_LONG_NAME)s use the code below (valid for "
 "%(timeout_minutes)s minutes):"
 msgstr ""
 
@@ -7146,13 +7146,13 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:8
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
 #, python-format
-msgid "If you have any questions, please contact us at %(org_email)s."
+msgid "If you have any questions, please contact us at %(ORG_EMAIL)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
 #, python-format
 msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
+"Login to your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -7167,7 +7167,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
 #, python-format
 msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
+"Your account on the %(ORG_LONG_NAME)s web site is deactivated. Please "
 "contact site administrators."
 msgstr ""
 
@@ -7179,27 +7179,27 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
 #, python-format
 msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
+"It looks like you are trying to login on %(ORG_LONG_NAME)s web site, but we "
 "could not find any account with the email provided."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
 #, python-format
 msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
+"Welcome to %(ORG_LONG_NAME)s web site. Create your account by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, python-format
 msgid ""
-"Set your account password on the %(org_long_name)s web site by clicking this "
+"Set your account password on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password_subject.txt:2
 #, python-format
-msgid "Set password for %(username)s at %(org_long_name)s"
+msgid "Set password for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/login.html:20
@@ -7364,7 +7364,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(org_long_name)s."
+"user account at %(ORG_LONG_NAME)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/password_reset/email.txt:6

--- a/hypha/locale/fr/LC_MESSAGES/django.po
+++ b/hypha/locale/fr/LC_MESSAGES/django.po
@@ -1266,6 +1266,7 @@ msgid "Dear %(user)s,"
 msgstr ""
 
 #: hypha/apply/activity/templates/messages/email/base.html:8
+#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
@@ -7099,13 +7100,6 @@ msgid ""
 "There has been an attempt to change email of your account on the "
 "%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
 "contact support at %(ORG_EMAIL)s "
-msgstr ""
-
-#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
-#, python-format
-msgid ""
-"Kind Regards,\n"
-"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4

--- a/hypha/locale/fr/LC_MESSAGES/django.po
+++ b/hypha/locale/fr/LC_MESSAGES/django.po
@@ -296,12 +296,12 @@ msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, python-brace-format
-msgid "Your application to {org_long_name}: {source.title_text_display}"
+msgid "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:140
 #, python-brace-format
-msgid "Your {org_long_name} Project: {source.title}"
+msgid "Your {ORG_LONG_NAME} Project: {source.title}"
 msgstr ""
 
 #: hypha/apply/activity/adapters/slack.py:31
@@ -4318,7 +4318,7 @@ msgstr ""
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:70
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:70
 #, python-brace-format
-msgid "{org_short_name} Review"
+msgid "{ORG_SHORT_NAME} Review"
 msgstr ""
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:87
@@ -5801,7 +5801,7 @@ msgstr ""
 #: hypha/apply/projects/templatetags/project_tags.py:83
 #, python-brace-format
 msgid ""
-"Awaiting project documents to be created and approved by {org_short_name} "
+"Awaiting project documents to be created and approved by {ORG_SHORT_NAME} "
 "internally. Please check back when the project has moved to contracting "
 "stage."
 msgstr ""
@@ -5840,7 +5840,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:158
 #, python-brace-format
-msgid "Awaiting signed contract from {org_short_name}"
+msgid "Awaiting signed contract from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:165
@@ -5873,7 +5873,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:207
 #, python-brace-format
-msgid "Awaiting contract approval from {org_short_name}"
+msgid "Awaiting contract approval from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:212
@@ -5890,7 +5890,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:242
 #, python-brace-format
-msgid "Please download the signed contract uploaded by {org_short_name}"
+msgid "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:244
@@ -6925,7 +6925,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/activation/email.txt:4
 #, python-format
 msgid ""
-"Activate your account on the %(org_long_name)s web site by clicking this "
+"Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -6972,12 +6972,12 @@ msgstr ""
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"The %(org_short_name)s Team"
+"The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
-msgid "Account details for %(username)s at %(org_long_name)s"
+msgid "Account details for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
@@ -7031,7 +7031,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
 msgid ""
-"Request to change email of your account on the %(org_long_name)s web site "
+"Request to change email of your account on the %(ORG_LONG_NAME)s web site "
 "has been accepted. Confirm your email by clicking this link or copying and "
 "pasting it to your browser:"
 msgstr ""
@@ -7097,21 +7097,21 @@ msgstr ""
 #, python-format
 msgid ""
 "There has been an attempt to change email of your account on the "
-"%(org_long_name)s web site. If this action wasn't made by you, please "
-"contact support at %(org_email)s "
+"%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
+"contact support at %(ORG_EMAIL)s "
 msgstr ""
 
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"    The %(org_short_name)s Team"
+"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format
 msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
+"To confirm access at %(ORG_LONG_NAME)s use the code below (valid for "
 "%(timeout_minutes)s minutes):"
 msgstr ""
 
@@ -7126,13 +7126,13 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:8
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
 #, python-format
-msgid "If you have any questions, please contact us at %(org_email)s."
+msgid "If you have any questions, please contact us at %(ORG_EMAIL)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
 #, python-format
 msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
+"Login to your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
@@ -7147,7 +7147,7 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
 #, python-format
 msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
+"Your account on the %(ORG_LONG_NAME)s web site is deactivated. Please "
 "contact site administrators."
 msgstr ""
 
@@ -7159,27 +7159,27 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
 #, python-format
 msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
+"It looks like you are trying to login on %(ORG_LONG_NAME)s web site, but we "
 "could not find any account with the email provided."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
 #, python-format
 msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
+"Welcome to %(ORG_LONG_NAME)s web site. Create your account by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, python-format
 msgid ""
-"Set your account password on the %(org_long_name)s web site by clicking this "
+"Set your account password on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/set_password_subject.txt:2
 #, python-format
-msgid "Set password for %(username)s at %(org_long_name)s"
+msgid "Set password for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/login.html:20
@@ -7344,7 +7344,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(org_long_name)s."
+"user account at %(ORG_LONG_NAME)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/password_reset/email.txt:6

--- a/hypha/locale/ru/LC_MESSAGES/django.po
+++ b/hypha/locale/ru/LC_MESSAGES/django.po
@@ -1347,6 +1347,7 @@ msgid "Dear %(user)s,"
 msgstr "Уважаемый(ая) %(user)s,"
 
 #: hypha/apply/activity/templates/messages/email/base.html:8
+#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
@@ -7799,15 +7800,6 @@ msgstr ""
 "На сайте %(ORG_LONG_NAME)s была предпринята попытка изменить электронную "
 "почту вашей учетной записи. Если это действие было совершено не вами, "
 "обратитесь к нам по адресу %(ORG_EMAIL)s "
-
-#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
-#, python-format
-msgid ""
-"Kind Regards,\n"
-"    The %(ORG_SHORT_NAME)s Team"
-msgstr ""
-"С наилучшими пожеланиями, \n"
-"    Команда %(ORG_SHORT_NAME)s"
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format

--- a/hypha/locale/ru/LC_MESSAGES/django.po
+++ b/hypha/locale/ru/LC_MESSAGES/django.po
@@ -321,14 +321,14 @@ msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, fuzzy, python-brace-format
-#| msgid "Your application to {org_long_name}: {source.title}"
-msgid "Your application to {org_long_name}: {source.title_text_display}"
-msgstr "Ваша заявка в {org_long_name}: {source.title}"
+#| msgid "Your application to {ORG_LONG_NAME}: {source.title}"
+msgid "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
+msgstr "Ваша заявка в {ORG_LONG_NAME}: {source.title}"
 
 #: hypha/apply/activity/adapters/emails.py:140
 #, python-brace-format
-msgid "Your {org_long_name} Project: {source.title}"
-msgstr "Ваш {org_long_name} проект: {source.title}"
+msgid "Your {ORG_LONG_NAME} Project: {source.title}"
+msgstr "Ваш {ORG_LONG_NAME} проект: {source.title}"
 
 #: hypha/apply/activity/adapters/slack.py:31
 #, fuzzy, python-brace-format
@@ -4706,8 +4706,8 @@ msgstr "Требуется скрининг (отменить)"
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:70
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:70
 #, python-brace-format
-msgid "{org_short_name} Review"
-msgstr "{org_short_name} ревью"
+msgid "{ORG_SHORT_NAME} Review"
+msgstr "{ORG_SHORT_NAME} ревью"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:87
 #: hypha/apply/funds/workflows/definitions/single_stage.py:87
@@ -6321,11 +6321,11 @@ msgstr "В ожидании"
 #: hypha/apply/projects/templatetags/project_tags.py:83
 #, python-brace-format
 msgid ""
-"Awaiting project documents to be created and approved by {org_short_name} "
+"Awaiting project documents to be created and approved by {ORG_SHORT_NAME} "
 "internally. Please check back when the project has moved to contracting "
 "stage."
 msgstr ""
-"Ожидание создания и утверждения проектных документов от {org_short_name}. "
+"Ожидание создания и утверждения проектных документов от {ORG_SHORT_NAME}. "
 "Пожалуйста, свяжитесь снова, когда проект будет готов к этапу оформления "
 "контракта."
 
@@ -6369,8 +6369,8 @@ msgstr "Ожидание одобрения проекта назначенны�
 
 #: hypha/apply/projects/templatetags/project_tags.py:158
 #, python-brace-format
-msgid "Awaiting signed contract from {org_short_name}"
-msgstr "Ожидаем подписания контракта от {org_short_name}"
+msgid "Awaiting signed contract from {ORG_SHORT_NAME}"
+msgstr "Ожидаем подписания контракта от {ORG_SHORT_NAME}"
 
 #: hypha/apply/projects/templatetags/project_tags.py:165
 #, fuzzy
@@ -6405,8 +6405,8 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:207
 #, python-brace-format
-msgid "Awaiting contract approval from {org_short_name}"
-msgstr "Ожидает одобрения контракта от {org_short_name}"
+msgid "Awaiting contract approval from {ORG_SHORT_NAME}"
+msgstr "Ожидает одобрения контракта от {ORG_SHORT_NAME}"
 
 #: hypha/apply/projects/templatetags/project_tags.py:212
 msgid "Awaiting contract approval from Staff"
@@ -6422,9 +6422,9 @@ msgstr "Проверьте инвойс и возьмите в работу"
 
 #: hypha/apply/projects/templatetags/project_tags.py:242
 #, python-brace-format
-msgid "Please download the signed contract uploaded by {org_short_name}"
+msgid "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
 msgstr ""
-"Пожалуйста, загрузите подписанный договор, загруженный {org_short_name}"
+"Пожалуйста, загрузите подписанный договор, загруженный {ORG_SHORT_NAME}"
 
 #: hypha/apply/projects/templatetags/project_tags.py:244
 msgid "Countersign"
@@ -7592,10 +7592,10 @@ msgstr "Включить двухфакторную аутентификацию
 #: hypha/apply/users/templates/users/activation/email.txt:4
 #, python-format
 msgid ""
-"Activate your account on the %(org_long_name)s web site by clicking this "
+"Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Активируйте свою учетную запись на сайте %(org_long_name)s, нажав на эту "
+"Активируйте свою учетную запись на сайте %(ORG_LONG_NAME)s, нажав на эту "
 "ссылку или скопировав и вставив ее в свой браузер:"
 
 #: hypha/apply/users/templates/users/activation/email.txt:8
@@ -7647,14 +7647,14 @@ msgstr ""
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"The %(org_short_name)s Team"
+"The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 "С наилучшими пожеланиями,\n"
-"Команда %(org_short_name)s"
+"Команда %(ORG_SHORT_NAME)s"
 
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
-msgid "Account details for %(username)s at %(org_long_name)s"
+msgid "Account details for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
@@ -7712,12 +7712,12 @@ msgstr "Назад к учетной записи"
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
 msgid ""
-"Request to change email of your account on the %(org_long_name)s web site "
+"Request to change email of your account on the %(ORG_LONG_NAME)s web site "
 "has been accepted. Confirm your email by clicking this link or copying and "
 "pasting it to your browser:"
 msgstr ""
 "Запрос на изменение электронной почты вашей учетной записи на сайте "
-"%(org_long_name)s был принят. Подтвердите свою электронную почту, нажав на "
+"%(ORG_LONG_NAME)s был принят. Подтвердите свою электронную почту, нажав на "
 "эту ссылку или скопировав и вставив ее в браузер:"
 
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:8
@@ -7793,26 +7793,26 @@ msgstr ""
 #, python-format
 msgid ""
 "There has been an attempt to change email of your account on the "
-"%(org_long_name)s web site. If this action wasn't made by you, please "
-"contact support at %(org_email)s "
+"%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
+"contact support at %(ORG_EMAIL)s "
 msgstr ""
-"На сайте %(org_long_name)s была предпринята попытка изменить электронную "
+"На сайте %(ORG_LONG_NAME)s была предпринята попытка изменить электронную "
 "почту вашей учетной записи. Если это действие было совершено не вами, "
-"обратитесь к нам по адресу %(org_email)s "
+"обратитесь к нам по адресу %(ORG_EMAIL)s "
 
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"    The %(org_short_name)s Team"
+"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 "С наилучшими пожеланиями, \n"
-"    Команда %(org_short_name)s"
+"    Команда %(ORG_SHORT_NAME)s"
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format
 msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
+"To confirm access at %(ORG_LONG_NAME)s use the code below (valid for "
 "%(timeout_minutes)s minutes):"
 msgstr ""
 
@@ -7828,19 +7828,19 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
 #, fuzzy, python-format
 #| msgid "If you have any questions, please submit them here"
-msgid "If you have any questions, please contact us at %(org_email)s."
+msgid "If you have any questions, please contact us at %(ORG_EMAIL)s."
 msgstr "Если у вас есть вопросы, пожалуйста, задайте их здесь"
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
+"Login to your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Активируйте свою учетную запись на сайте %(org_long_name)s, нажав на эту "
+"Активируйте свою учетную запись на сайте %(ORG_LONG_NAME)s, нажав на эту "
 "ссылку или скопировав и вставив ее в свой браузер:"
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:9
@@ -7854,13 +7854,13 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
+"Your account on the %(ORG_LONG_NAME)s web site is deactivated. Please "
 "contact site administrators."
 msgstr ""
-"Активируйте свою учетную запись на сайте %(org_long_name)s, нажав на эту "
+"Активируйте свою учетную запись на сайте %(ORG_LONG_NAME)s, нажав на эту "
 "ссылку или скопировав и вставив ее в свой браузер:"
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:3
@@ -7871,37 +7871,37 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
 #, python-format
 msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
+"It looks like you are trying to login on %(ORG_LONG_NAME)s web site, but we "
 "could not find any account with the email provided."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
+"Welcome to %(ORG_LONG_NAME)s web site. Create your account by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Активируйте свою учетную запись на сайте %(org_long_name)s, нажав на эту "
+"Активируйте свою учетную запись на сайте %(ORG_LONG_NAME)s, нажав на эту "
 "ссылку или скопировав и вставив ее в свой браузер:"
 
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Set your account password on the %(org_long_name)s web site by clicking this "
+"Set your account password on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"Активируйте свою учетную запись на сайте %(org_long_name)s, нажав на эту "
+"Активируйте свою учетную запись на сайте %(ORG_LONG_NAME)s, нажав на эту "
 "ссылку или скопировав и вставив ее в свой браузер:"
 
 #: hypha/apply/users/templates/users/emails/set_password_subject.txt:2
 #, python-format
-msgid "Set password for %(username)s at %(org_long_name)s"
+msgid "Set password for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/login.html:20
@@ -8109,10 +8109,10 @@ msgstr ""
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(org_long_name)s."
+"user account at %(ORG_LONG_NAME)s."
 msgstr ""
 "Вы получили это письмо, потому что запросили сброс пароля для вашей учетной "
-"записи %(org_long_name)s."
+"записи %(ORG_LONG_NAME)s."
 
 #: hypha/apply/users/templates/users/password_reset/email.txt:6
 msgid "Please follow the link below to reset your password:"
@@ -8718,9 +8718,9 @@ msgstr "Пожалуйста, введите пароль, чтобы продо
 #~ msgstr "Инвойс ожидает вашего утверждения."
 
 #, fuzzy, python-brace-format
-#~| msgid "Your application to {org_long_name}: {source.title}"
-#~ msgid "Confirmation code for {org_long_name}: {token}"
-#~ msgstr "Ваша заявка в {org_long_name}: {source.title}"
+#~| msgid "Your application to {ORG_LONG_NAME}: {source.title}"
+#~ msgid "Confirmation code for {ORG_LONG_NAME}: {token}"
+#~ msgstr "Ваша заявка в {ORG_LONG_NAME}: {source.title}"
 
 #~ msgid "Submit for Approval"
 #~ msgstr "Отправить на утверждение"

--- a/hypha/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/hypha/locale/zh_Hans/LC_MESSAGES/django.po
@@ -330,14 +330,14 @@ msgstr ""
 
 #: hypha/apply/activity/adapters/emails.py:137
 #, fuzzy, python-brace-format
-#| msgid "Your application to {org_long_name}: {source.title}"
-msgid "Your application to {org_long_name}: {source.title_text_display}"
-msgstr "您给 {org_long_name} 的项目：{source.title}"
+#| msgid "Your application to {ORG_LONG_NAME}: {source.title}"
+msgid "Your application to {ORG_LONG_NAME}: {source.title_text_display}"
+msgstr "您给 {ORG_LONG_NAME} 的项目：{source.title}"
 
 #: hypha/apply/activity/adapters/emails.py:140
 #, python-brace-format
-msgid "Your {org_long_name} Project: {source.title}"
-msgstr "您的 {org_long_name} 项目：{source.title}"
+msgid "Your {ORG_LONG_NAME} Project: {source.title}"
+msgstr "您的 {ORG_LONG_NAME} 项目：{source.title}"
 
 #: hypha/apply/activity/adapters/slack.py:31
 #, fuzzy, python-brace-format
@@ -1426,13 +1426,13 @@ msgstr "亲爱的 %(user)s，"
 #, fuzzy, python-format
 #| msgid ""
 #| "Kind Regards,\n"
-#| "The %(org_short_name)s Team"
+#| "The %(ORG_SHORT_NAME)s Team"
 msgid ""
 "Kind Regards,\n"
 "    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 "谨致问候，\n"
-"%(org_short_name)s 团队"
+"%(ORG_SHORT_NAME)s 团队"
 
 #: hypha/apply/activity/templates/messages/email/batch_ready_to_review.html:4
 #: hypha/apply/activity/templates/messages/email/ready_to_review.html:4
@@ -4812,8 +4812,8 @@ msgstr "需要审查（回复）"
 #: hypha/apply/funds/workflows/definitions/single_stage_external.py:70
 #: hypha/apply/funds/workflows/definitions/single_stage_same.py:70
 #, python-brace-format
-msgid "{org_short_name} Review"
-msgstr "{org_short_name} 审核"
+msgid "{ORG_SHORT_NAME} Review"
+msgstr "{ORG_SHORT_NAME} 审核"
 
 #: hypha/apply/funds/workflows/definitions/double_stage.py:87
 #: hypha/apply/funds/workflows/definitions/single_stage.py:87
@@ -6486,7 +6486,7 @@ msgstr "等待中"
 #: hypha/apply/projects/templatetags/project_tags.py:83
 #, python-brace-format
 msgid ""
-"Awaiting project documents to be created and approved by {org_short_name} "
+"Awaiting project documents to be created and approved by {ORG_SHORT_NAME} "
 "internally. Please check back when the project has moved to contracting "
 "stage."
 msgstr ""
@@ -6525,7 +6525,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:158
 #, python-brace-format
-msgid "Awaiting signed contract from {org_short_name}"
+msgid "Awaiting signed contract from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:165
@@ -6558,7 +6558,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:207
 #, python-brace-format
-msgid "Awaiting contract approval from {org_short_name}"
+msgid "Awaiting contract approval from {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:212
@@ -6577,7 +6577,7 @@ msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:242
 #, python-brace-format
-msgid "Please download the signed contract uploaded by {org_short_name}"
+msgid "Please download the signed contract uploaded by {ORG_SHORT_NAME}"
 msgstr ""
 
 #: hypha/apply/projects/templatetags/project_tags.py:244
@@ -7688,10 +7688,10 @@ msgstr "启用双重验证"
 #: hypha/apply/users/templates/users/activation/email.txt:4
 #, python-format
 msgid ""
-"Activate your account on the %(org_long_name)s web site by clicking this "
+"Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(org_long_name)s 网站的账"
+"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(ORG_LONG_NAME)s 网站的账"
 "户："
 
 #: hypha/apply/users/templates/users/activation/email.txt:8
@@ -7741,14 +7741,14 @@ msgstr ""
 #, python-format
 msgid ""
 "Kind Regards,\n"
-"The %(org_short_name)s Team"
+"The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 "谨致问候，\n"
-"%(org_short_name)s 团队"
+"%(ORG_SHORT_NAME)s 团队"
 
 #: hypha/apply/users/templates/users/activation/email_subject.txt:2
 #, python-format
-msgid "Account details for %(username)s at %(org_long_name)s"
+msgid "Account details for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/activation/invalid.html:4
@@ -7808,11 +7808,11 @@ msgstr "返回账户"
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:4
 #, python-format
 msgid ""
-"Request to change email of your account on the %(org_long_name)s web site "
+"Request to change email of your account on the %(ORG_LONG_NAME)s web site "
 "has been accepted. Confirm your email by clicking this link or copying and "
 "pasting it to your browser:"
 msgstr ""
-"您在 %(org_long_name)s 网站账户的电子邮箱更改请求已被批准。请点击此链接确认邮"
+"您在 %(ORG_LONG_NAME)s 网站账户的电子邮箱更改请求已被批准。请点击此链接确认邮"
 "箱，或者将其复制并粘贴到浏览器中："
 
 #: hypha/apply/users/templates/users/email_change/confirm_email.txt:8
@@ -7884,26 +7884,26 @@ msgstr ""
 #, python-format
 msgid ""
 "There has been an attempt to change email of your account on the "
-"%(org_long_name)s web site. If this action wasn't made by you, please "
-"contact support at %(org_email)s "
+"%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
+"contact support at %(ORG_EMAIL)s "
 msgstr ""
 
 #: hypha/apply/users/templates/users/email_change/update_info_email.html:7
 #, fuzzy, python-format
 #| msgid ""
 #| "Kind Regards,\n"
-#| "The %(org_short_name)s Team"
+#| "The %(ORG_SHORT_NAME)s Team"
 msgid ""
 "Kind Regards,\n"
-"    The %(org_short_name)s Team"
+"    The %(ORG_SHORT_NAME)s Team"
 msgstr ""
 "谨致问候，\n"
-"%(org_short_name)s 团队"
+"%(ORG_SHORT_NAME)s 团队"
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format
 msgid ""
-"To confirm access at %(org_long_name)s use the code below (valid for "
+"To confirm access at %(ORG_LONG_NAME)s use the code below (valid for "
 "%(timeout_minutes)s minutes):"
 msgstr ""
 
@@ -7919,19 +7919,19 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:13
 #, fuzzy, python-format
 #| msgid "If you have any questions, please submit them here"
-msgid "If you have any questions, please contact us at %(org_email)s."
+msgid "If you have any questions, please contact us at %(ORG_EMAIL)s."
 msgstr "若您有任何问题，请在这里提交"
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:5
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Login to your account on the %(org_long_name)s web site by clicking this "
+"Login to your account on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(org_long_name)s 网站的账"
+"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(ORG_LONG_NAME)s 网站的账"
 "户："
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:9
@@ -7945,13 +7945,13 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_email.md:12
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Your account on the %(org_long_name)s web site is deactivated. Please "
+"Your account on the %(ORG_LONG_NAME)s web site is deactivated. Please "
 "contact site administrators."
 msgstr ""
-"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(org_long_name)s 网站的账"
+"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(ORG_LONG_NAME)s 网站的账"
 "户："
 
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:3
@@ -7962,37 +7962,37 @@ msgstr ""
 #: hypha/apply/users/templates/users/emails/passwordless_login_no_account_found.md:5
 #, python-format
 msgid ""
-"It looks like you are trying to login on %(org_long_name)s web site, but we "
+"It looks like you are trying to login on %(ORG_LONG_NAME)s web site, but we "
 "could not find any account with the email provided."
 msgstr ""
 
 #: hypha/apply/users/templates/users/emails/passwordless_new_account_login.md:4
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Welcome to %(org_long_name)s web site. Create your account by clicking this "
+"Welcome to %(ORG_LONG_NAME)s web site. Create your account by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(org_long_name)s 网站的账"
+"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(ORG_LONG_NAME)s 网站的账"
 "户："
 
 #: hypha/apply/users/templates/users/emails/set_password.txt:4
 #, fuzzy, python-format
 #| msgid ""
-#| "Activate your account on the %(org_long_name)s web site by clicking this "
+#| "Activate your account on the %(ORG_LONG_NAME)s web site by clicking this "
 #| "link or copying and pasting it to your browser:"
 msgid ""
-"Set your account password on the %(org_long_name)s web site by clicking this "
+"Set your account password on the %(ORG_LONG_NAME)s web site by clicking this "
 "link or copying and pasting it to your browser:"
 msgstr ""
-"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(org_long_name)s 网站的账"
+"点击此链接或将其复制并粘贴到浏览器中，以激活您在 %(ORG_LONG_NAME)s 网站的账"
 "户："
 
 #: hypha/apply/users/templates/users/emails/set_password_subject.txt:2
 #, python-format
-msgid "Set password for %(username)s at %(org_long_name)s"
+msgid "Set password for %(username)s at %(ORG_LONG_NAME)s"
 msgstr ""
 
 #: hypha/apply/users/templates/users/login.html:20
@@ -8180,7 +8180,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(org_long_name)s."
+"user account at %(ORG_LONG_NAME)s."
 msgstr ""
 
 #: hypha/apply/users/templates/users/password_reset/email.txt:6
@@ -8755,9 +8755,9 @@ msgstr "请输入密码以继续。"
 #~ msgstr "您正为如下阶段进行报告"
 
 #, fuzzy, python-brace-format
-#~| msgid "Your application to {org_long_name}: {source.title}"
-#~ msgid "Confirmation code for {org_long_name}: {token}"
-#~ msgstr "您给 {org_long_name} 的项目：{source.title}"
+#~| msgid "Your application to {ORG_LONG_NAME}: {source.title}"
+#~ msgid "Confirmation code for {ORG_LONG_NAME}: {token}"
+#~ msgstr "您给 {ORG_LONG_NAME} 的项目：{source.title}"
 
 #~ msgid "Submit for Approval"
 #~ msgstr "提交以批准"

--- a/hypha/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/hypha/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1423,10 +1423,8 @@ msgid "Dear %(user)s,"
 msgstr "亲爱的 %(user)s，"
 
 #: hypha/apply/activity/templates/messages/email/base.html:8
-#, fuzzy, python-format
-#| msgid ""
-#| "Kind Regards,\n"
-#| "The %(ORG_SHORT_NAME)s Team"
+#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
+#, python-format
 msgid ""
 "Kind Regards,\n"
 "    The %(ORG_SHORT_NAME)s Team"
@@ -7887,18 +7885,6 @@ msgid ""
 "%(ORG_LONG_NAME)s web site. If this action wasn't made by you, please "
 "contact support at %(ORG_EMAIL)s "
 msgstr ""
-
-#: hypha/apply/users/templates/users/email_change/update_info_email.html:7
-#, fuzzy, python-format
-#| msgid ""
-#| "Kind Regards,\n"
-#| "The %(ORG_SHORT_NAME)s Team"
-msgid ""
-"Kind Regards,\n"
-"    The %(ORG_SHORT_NAME)s Team"
-msgstr ""
-"谨致问候，\n"
-"%(ORG_SHORT_NAME)s 团队"
 
 #: hypha/apply/users/templates/users/emails/confirm_access.md:4
 #, python-format


### PR DESCRIPTION
I noticed that the signature of the application notification emails was off:
```
Kind Regards,
The  Team

--

http://example.com
```

While investigating I found out that the `base.html` email template was using `org_long_name` instead of `ORG_LONG_NAME` (which is what the `global_vars` [context processor](https://github.com/HyphaApp/hypha/blob/d26405a02bf8ef8ac348992c3a12f6c100f82bab/hypha/core/context_processors.py#L6) is providing).
This issue appears to be widespread, and it's not helped by the fact that some emails correctly receive the `org_long_name` variable (it's passed manually in the context).

For this PR, I went with the exhaustive approach of replacing every single instance of `org_long_name`, `org_short_name`, and `org_email` with their uppercase counterparts:
```
git grep -lw org_long_name | xargs sed -i 's/\borg_long_name\b/ORG_LONG_NAME/'
git grep -lw org_short_name | xargs sed -i 's/\borg_short_name\b/ORG_SHORT_NAME/'
git grep -lw org_email | xargs sed -i 's/\borg_email\b/ORG_EMAIL/'
```