### PR TITLE
Restore colors for word limit warning message in tinymce widget

### DIFF
--- a/hypha/static_src/tailwind/components/tinymce.css
+++ b/hypha/static_src/tailwind/components/tinymce.css
@@ -45,14 +45,14 @@
 
   .tox-statusbar__wordcount.word-count-warning,
   .tox-statusbar__wordcount.word-count-warning-2 {
-    background-color: var(--color-warning);
-    color: var(--color-warning-content);
-    font-weight: bold;
+    background-color: var(--color-warning) !important;
+    color: var(--color-warning-content) !important;
+    font-weight: bold !important;
   }
 
   .tox-statusbar__wordcount.word-count-warning-2 {
-    background-color: var(--color-error);
-    color: var(--color-error-content);
+    background-color: var(--color-error) !important;
+    color: var(--color-error-content) !important;
   }
 
   .tox-statusbar a,


### PR DESCRIPTION
The colors went missing with the daisyUI refactor 9cfc791538a13aa222c59996666b00ba64ab09af

The use of `!important` is not great, but it's already widespread inside this file (because the tinymce stylesheet is loaded after Hypha's and therefore takes precedence).

## Screenshots

<details><summary>Before</summary>

<img width="768" height="546" alt="Screenshot 2025-11-27 at 16-26-51 Max words" src="https://github.com/user-attachments/assets/196c9cff-16c0-47db-aff6-6d2609313d3a" />


</details> 

<details><summary>After</summary>

<img width="768" height="546" alt="Screenshot 2025-11-27 at 16-29-04 Max words" src="https://github.com/user-attachments/assets/592c58e8-8c0d-4afc-b824-eb31db087f28" />


</details> 