### PR TITLE
Added `global_vars` to `MarkdownMail` rendering, removed redundant contexts

### DIFF
--- a/hypha/apply/users/services.py
+++ b/hypha/apply/users/services.py
@@ -92,45 +92,28 @@ class PasswordlessAuthService:
 
         return None
 
-    def get_email_context(self) -> dict:
-        return {
-            "ORG_LONG_NAME": settings.ORG_LONG_NAME,
-            "ORG_EMAIL": settings.ORG_EMAIL,
-            "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
-            "site": self.site,
-        }
-
     def send_email_no_account_found(self, to):
-        context = self.get_email_context()
-        subject = "Log in attempt at {ORG_LONG_NAME}".format(**context)
+        subject = f"Log in attempt at {settings.ORG_LONG_NAME}"
         # Force subject to a single line to avoid header-injection issues.
         subject = "".join(subject.splitlines())
 
         email = MarkdownMail("users/emails/passwordless_login_no_account_found.md")
-        email.send(
-            to=to,
-            subject=subject,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            context=context,
-        )
+        email.send(to=to, subject=subject, from_email=settings.DEFAULT_FROM_EMAIL)
 
     def send_login_email(self, user):
         login_path = self._get_login_path(user)
         timeout_minutes = self.login_token_generator_class().TIMEOUT // 60
 
-        context = self.get_email_context()
-        context.update(
-            {
-                "user": user,
-                "is_active": user.is_active,
-                "name": user.get_full_name(),
-                "username": user.get_username(),
-                "login_path": login_path,
-                "timeout_minutes": timeout_minutes,
-            }
-        )
+        context = {
+            "user": user,
+            "is_active": user.is_active,
+            "name": user.get_full_name(),
+            "username": user.get_username(),
+            "login_path": login_path,
+            "timeout_minutes": timeout_minutes,
+        }
 
-        subject = "Log in to {username} at {ORG_LONG_NAME}".format(**context)
+        subject = f"Log in to {user.get_username()} at {settings.ORG_LONG_NAME}"
         # Force subject to a single line to avoid header-injection issues.
         subject = "".join(subject.splitlines())
 
@@ -146,15 +129,12 @@ class PasswordlessAuthService:
         signup_path = self._get_signup_path(signup_obj)
         timeout_minutes = self.login_token_generator_class().TIMEOUT // 60
 
-        context = self.get_email_context()
-        context.update(
-            {
-                "signup_path": signup_path,
-                "timeout_minutes": timeout_minutes,
-            }
-        )
+        context = {
+            "signup_path": signup_path,
+            "timeout_minutes": timeout_minutes,
+        }
 
-        subject = "Welcome to {ORG_LONG_NAME}".format(**context)
+        subject = f"Welcome to {settings.ORG_LONG_NAME}"
         # Force subject to a single line to avoid header-injection issues.
         subject = "".join(subject.splitlines())
 

--- a/hypha/apply/users/views.py
+++ b/hypha/apply/users/views.py
@@ -728,16 +728,13 @@ def send_confirm_access_email_view(request):
         user=request.user, token=generate_numeric_token
     )
     email_context = {
-        "ORG_LONG_NAME": settings.ORG_LONG_NAME,
-        "ORG_EMAIL": settings.ORG_EMAIL,
-        "ORG_SHORT_NAME": settings.ORG_SHORT_NAME,
         "token": token_obj.token,
         "username": request.user.email,
         "site": Site.find_for_request(request),
         "user": request.user,
         "timeout_minutes": settings.PASSWORDLESS_LOGIN_TIMEOUT // 60,
     }
-    subject = "Confirmation code for {ORG_LONG_NAME}: {token}".format(**email_context)
+    subject = f"Confirmation code for {settings.ORG_LONG_NAME}: {token_obj.token}"
     email = MarkdownMail("users/emails/confirm_access.md")
     email.send(
         to=request.user.email,

--- a/hypha/core/mail.py
+++ b/hypha/core/mail.py
@@ -8,6 +8,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.template import TemplateDoesNotExist, loader
 from django.utils import translation
 
+from hypha.core.context_processors import global_vars
 from hypha.core.utils import markdown_to_html
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ class MarkdownMail(object):
 
     def _render_template(self, context: Dict) -> str:
         try:
+            context.update(global_vars(None))
             return loader.render_to_string(self.template_name, context)
         except TemplateDoesNotExist as e:
             logger.warning("Template '{0}' does not exists.".format(e))


### PR DESCRIPTION
…`MarkdownMail` renderer

<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Relates to #4638 - removes the redundant markdown email contexts in favor of just utilizing the `global_vars` context processor 


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure all markdown emails still look as they did before