### PR TITLE
Fix elevate view link styling

### DIFF
--- a/hypha/apply/users/templates/elevate/elevate.html
+++ b/hypha/apply/users/templates/elevate/elevate.html
@@ -51,7 +51,7 @@
                     <ul class="list-disc ms-4">
                         <li>
                             <a
-                                class="m-0"
+                                class="m-0 link"
                                 type="submit"
                                 hx-post="{% url 'users:elevate_send_confirm_access_email' %}{% if request.GET.next %}?next={{request.GET.next}}{% endif %}"
                                 hx-target="#section-form"

--- a/hypha/apply/users/templates/users/partials/confirmation_code_sent.html
+++ b/hypha/apply/users/templates/users/partials/confirmation_code_sent.html
@@ -60,7 +60,7 @@
         <ul class="list-disc ms-4">
             <li>
                 <a
-                    class="m-0"
+                    class="m-0 link"
                     type="submit"
                     hx-boost="true"
                     href="{% url 'users:elevate' %}{% if redirect_url %}?next={{ redirect_url }}{% endif %}"


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
The `Having Problems?` prompts in the elevate view didn't indicate any of the options were clickable, this fix adds link styling to them
