### PR TITLE
Fix wagtail 2FA disable confirm button styling

### DIFF
--- a/hypha/apply/users/templates/two_factor/admin/disable.html
+++ b/hypha/apply/users/templates/two_factor/admin/disable.html
@@ -19,7 +19,7 @@
                     {% endblock %}
 
                     <li>
-                        <button class="btn btn-primary" type="submit">{% trans 'Confirm' %}</button>
+                        <button class="button" type="submit">{% trans 'Confirm' %}</button>
                     </li>
                 </ul>
 


### PR DESCRIPTION
swapped `btn` for wagtail's `button` class