### PR TITLE
Fixed incorrect proposal form rendering and improved order of fields

### DIFF
--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -359,6 +359,10 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
                     form_fields[field_block.id].initial = TRANSITION_DETERMINATION[
                         action
                     ]
+            # Make capitalization consistent
+            form_fields[field_block.id].label = form_fields[
+                field_block.id
+            ].label.title()
         form_fields = self.add_proposal_form_field(form_fields, action)
         return type("WagtailStreamForm", (self.submission_form_class,), form_fields)
 
@@ -389,7 +393,11 @@ class DeterminationCreateOrUpdateView(BaseStreamForm, CreateOrUpdateView):
                     help_text=proposal_form_help_text,
                     required=True if action == "invited_to_proposal" else False,
                 )
+                # Move proposal form the be the second field as it's disabled until the first (determination) is input
                 fields.move_to_end("proposal_form", last=False)
+                fields.move_to_end(
+                    list(fields.keys())[1], last=False
+                )  # `last=False` moves the item to the start
         return fields
 
     def get_success_url(self):

--- a/hypha/apply/funds/models/utils.py
+++ b/hypha/apply/funds/models/utils.py
@@ -115,7 +115,7 @@ class WorkflowStreamForm(WorkflowHelpers, AbstractStreamForm):  # type: ignore
             stage_num = 1
         else:
             stage_num = self.workflow.stages.index(stage) + 1
-        return self.forms.filter(stage=stage_num)[form_index].fields
+        return list(self.forms.filter(stage=stage_num))[form_index].fields
 
     def render_landing_page(self, request, form_submission=None, *args, **kwargs):
         # We only reach this page after creation of a new submission

--- a/hypha/static_src/javascript/determination-template.js
+++ b/hypha/static_src/javascript/determination-template.js
@@ -25,23 +25,23 @@
 
     getMatchingCopy(value) {
       const proposal_form = document.querySelector("#id_proposal_form");
-      if (value === "0") {
-        this.text = document.querySelector(
-          'div[data-type="rejected"]'
-        ).textContent;
+      if (["", "0", "1"].includes(value)) {
         if (proposal_form) {
           proposal_form.disabled = true;
           proposal_form.required = false;
         }
-      } else if (value === "1") {
-        this.text = document.querySelector(
-          'div[data-type="more_info"]'
-        ).textContent;
-        if (proposal_form) {
-          proposal_form.disabled = true;
-          proposal_form.required = false;
+        if (value === "") {
+          this.text = "";
+        } else if (value === "0") {
+          this.text = document.querySelector(
+            'div[data-type="rejected"]'
+          ).textContent;
+        } else if (value === "1") {
+          this.text = document.querySelector(
+            'div[data-type="more_info"]'
+          ).textContent;
         }
-      } else {
+      } else if (value === "2") {
         this.text = document.querySelector(
           'div[data-type="accepted"]'
         ).textContent;


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4652. Wraps the queryset in a `list` and changes the order of the fields into a more logical one where "Determinations" comes first, as it's selection is required to enable "Proposal Form"


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] Ensure the expected proposal form is rendered
 - [ ] Ensure that the "Determination" field is rendered before "Proposal Form"