### PR TITLE
Fix concept note & proposal both appearing in user's dashboard

### DIFF
--- a/hypha/apply/dashboard/views_partials.py
+++ b/hypha/apply/dashboard/views_partials.py
@@ -17,6 +17,7 @@ def my_active_submissions(user):
         .annotate(
             is_active=Case(When(status__in=active_statuses, then=True), default=False)
         )
+        .current()
         .select_related("draft_revision")
         .order_by("-is_active", "-submit_time")
         .distinct()


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4651. Removes duplicate applications (concept note/proposal) from the user dashboard. Thanks for the fix suggestion @frjo! 


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] As an applicant, submit a concept note
 - [ ] As staff, invite said application to proposal
 - [ ] As previous applicant, ensure only the proposal shows up on the dashboard