### PR TITLE
Add a notice to notifications if recived as co-applicant.

### DIFF
--- a/hypha/apply/activity/templates/messages/email/applicant_base.html
+++ b/hypha/apply/activity/templates/messages/email/applicant_base.html
@@ -1,6 +1,13 @@
 {% extends "messages/email/base.html" %}
 
 {% load i18n %}
+
+{# fmt:off #}
+{% block pre_salutation %}{% for co_applicant in source.co_applicants.all %}{% if recipient == co_applicant.user.email %}
+({% trans "You are receiving this e-mail because you are an co-applicant on this submission." %})
+{% endif %}{% endfor %}{% endblock %}
+{# fmt:on #}
+
 {% block salutation %}{% blocktrans with name=source.user.get_full_name|default:"applicant" %}Dear {{ name }},{% endblocktrans %}{% endblock %}
 
 {# fmt:off #}

--- a/hypha/apply/activity/templates/messages/email/base.html
+++ b/hypha/apply/activity/templates/messages/email/base.html
@@ -1,4 +1,7 @@
 {% load i18n %}
+
+{% block pre_salutation %}{% endblock %}
+
 {% block salutation %}{% blocktrans %}Dear {{ user }},{% endblocktrans %}{% endblock %}
 
 {% block content %}{% endblock %}


### PR DESCRIPTION
Fixes #4618

This PR adds the line "(You are receiving this e-mail because you are an co-applicant on this submission.)" on top of the e-mail for co-applicants.

## Test Steps

 - [ ] Make sure that applicant e-mails that are also sent out to co-applicants include the line above.