### PR TITLE
Added a button to disable 2FA for a specific user

### DIFF
--- a/hypha/apply/users/templates/wagtailusers/users/edit.html
+++ b/hypha/apply/users/templates/wagtailusers/users/edit.html
@@ -1,4 +1,17 @@
 {% extends "wagtailusers/users/edit.html" %}
+{% load users_tags i18n %}
+
+{% block actions %}
+    {{ block.super }}
+    {% user_2fa_enabled user as is_2fa_enabled %}
+    {% if is_2fa_enabled %}
+        <a class="button serious button-longrunning" href="{% url 'users:admin_disable' user.pk %}">
+            {% trans "Disable 2FA" %}
+        </a>
+    {% else %}
+        <button type="button" title="{% trans "This account do not have 2FA enabled." %}" class="button" disabled>{% trans "2FA is disabled" %}</button>
+    {% endif %}
+{% endblock %}
 
 {% block extra_fields %}
     <li>{% include "wagtailadmin/shared/field.html" with field=form.full_name %}</li>

--- a/hypha/apply/users/templates/wagtailusers/users/edit.html
+++ b/hypha/apply/users/templates/wagtailusers/users/edit.html
@@ -9,7 +9,7 @@
             {% trans "Disable 2FA" %}
         </a>
     {% else %}
-        <button type="button" title="{% trans "This account do not have 2FA enabled." %}" class="button" disabled>{% trans "2FA is disabled" %}</button>
+        <button type="button" title="{% trans "This account does not have 2FA enabled." %}" class="button" disabled>{% trans "2FA is disabled" %}</button>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4746. Adds a button to the user edit view that allows for disabling of 2FA. Instead of it being on the form, it's in the actions bar.


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [x] Ensure using the `Disable 2FA` button works for users that have it enabled
 - [x] For users that don't, it should show `2FA is disabled`