### PR TITLE
Added url to open calls API

### DIFF
--- a/hypha/apply/funds/models/applications.py
+++ b/hypha/apply/funds/models/applications.py
@@ -101,6 +101,7 @@ class AsJsonMixin:
             "image": image,
             "weight": weight,
             "next_deadline": next_deadline,
+            "url": self.get_url(),
         }
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4748. Adds a `url` attribute to the `open-calls` JSON API endpoint


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [x] Ensure that when requesting from `/api/v2/open-calls.json`, a correct `url` attribute is provided