### PR TITLE
Only target the first title column, not all of them

### DIFF
--- a/hypha/static_src/sass/wagtail_global_admin.css
+++ b/hypha/static_src/sass/wagtail_global_admin.css
@@ -1,4 +1,4 @@
 /* Make title column in wagtail admin listing views have a min-width. */
-.listing .title {
+.listing .field-title {
   min-width: 20vw;
 }


### PR DESCRIPTION
The original css override set the min-width on all title column. not just the first as it should.