### PR TITLE
Make translate test handle no translate packages installed.

### DIFF
--- a/hypha/apply/funds/tests/conftest.py
+++ b/hypha/apply/funds/tests/conftest.py
@@ -1,0 +1,1 @@
+import hypha.apply.funds.urls  # noqa: F401 - pre-loads all fund views at collection time


### PR DESCRIPTION
This fix loads the urls that loads the views before tests are run. This avoid them being loaded after @override_settings() have run. 

The problem showed up in `test_staff_can_see_translate_primary_action()` test that have `@override_settings(APPLICATION_TRANSLATIONS_ENABLED=True)`.

Loading views after `@override_settings(APPLICATION_TRANSLATIONS_ENABLED=True)` made them look for translation packages that were not installed resulting in failed tests.