### PR TITLE
Lower memory usage in submissions and projects

### DIFF
--- a/hypha/apply/activity/models.py
+++ b/hypha/apply/activity/models.py
@@ -236,7 +236,7 @@ class Activity(models.Model):
     def get_absolute_url(self):
         # coverup for both submission and project as source.
         submission_id = (
-            self.source.submission.id
+            self.source.submission_id
             if hasattr(self.source, "submission")
             else self.source.id
         )

--- a/hypha/apply/dashboard/services.py
+++ b/hypha/apply/dashboard/services.py
@@ -1,28 +1,28 @@
-from django.db.models import Count
+from django.db.models import Count, Exists, OuterRef
 
 from hypha.apply.projects.models import PAFApprovals
 
 
 def get_paf_for_review(user, is_paf_approval_sequential):
-    """Return a list of paf approvals ready for user's review"""
+    """Return a queryset of paf approvals ready for user's review"""
+    user_groups = list(user.groups.all())
 
     paf_approvals = PAFApprovals.objects.annotate(
         roles_count=Count("paf_reviewer_role__user_roles")
     ).filter(
-        roles_count=user.groups.count(),
+        roles_count=len(user_groups),
         approved=False,
     )
 
-    for role in user.groups.all():
+    for role in user_groups:
         paf_approvals = paf_approvals.filter(paf_reviewer_role__user_roles__id=role.id)
 
     if is_paf_approval_sequential:
-        all_matched_paf_approvals = list(paf_approvals)
-        for matched_paf_approval in all_matched_paf_approvals:
-            if matched_paf_approval.project.paf_approvals.filter(
-                paf_reviewer_role__sort_order__lt=matched_paf_approval.paf_reviewer_role.sort_order,
-                approved=False,
-            ).exists():
-                paf_approvals = paf_approvals.exclude(id=matched_paf_approval.id)
+        blocking_step = PAFApprovals.objects.filter(
+            project=OuterRef("project"),
+            approved=False,
+            paf_reviewer_role__sort_order__lt=OuterRef("paf_reviewer_role__sort_order"),
+        )
+        paf_approvals = paf_approvals.exclude(Exists(blocking_step))
 
     return paf_approvals

--- a/hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/contracting_dashboard.html
@@ -41,7 +41,7 @@
         </section>
 
 
-        {% if projects_in_contracting.count %}
+        {% if PROJECTS_ENABLED and projects_in_contracting.count %}
             {% include "dashboard/includes/projects_in_contracting.html" with projects_in_contracting=projects_in_contracting %}
         {% endif %}
     </div>

--- a/hypha/apply/dashboard/templates/dashboard/finance_dashboard.html
+++ b/hypha/apply/dashboard/templates/dashboard/finance_dashboard.html
@@ -92,7 +92,7 @@
         <section id="paf_for_review">
             <h2 class="section-header">{% trans "PAFs for review" %}</h2>
             <div class="overflow-x-auto border rounded-box">
-                {% if not paf_for_review.count %}
+                {% if PROJECTS_ENABLED and paf_for_review.count %}
                     {% render_table paf_for_review.table %}
                 {% else %}
                     <p class="p-4 text-sm text-fg-muted">

--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -82,7 +82,7 @@ class PAFReviewMixin:
             get_paf_for_review(
                 user=self.request.user,
                 is_paf_approval_sequential=project_settings.paf_approval_sequential,
-            )
+            ).select_related("project__submission__page", "paf_reviewer_role", "user")
         )
         paf_table = PAFForReviewDashboardTable(
             paf_approvals, prefix="paf-review-", order_by="-date_requested"

--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -137,9 +137,13 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
         }
 
     def active_invoices(self):
-        invoices = Invoice.objects.filter(
-            project__lead=self.request.user,
-        ).in_progress()
+        invoices = (
+            Invoice.objects.filter(
+                project__lead=self.request.user,
+            )
+            .in_progress()
+            .select_related("project")
+        )
 
         return {
             "count": invoices.count(),
@@ -223,7 +227,7 @@ class FinanceDashboardView(MyFlaggedMixin, TemplateView):
         }
 
     def active_invoices(self):
-        invoices = Invoice.objects.for_finance_1()
+        invoices = Invoice.objects.for_finance_1().select_related("project")
 
         return {
             "count": invoices.count(),
@@ -231,12 +235,12 @@ class FinanceDashboardView(MyFlaggedMixin, TemplateView):
         }
 
     def invoices_for_approval(self):
-        invoices = Invoice.objects.approved_by_staff()
+        invoices = Invoice.objects.approved_by_staff().select_related("project")
 
         return {"count": invoices.count(), "table": InvoiceDashboardTable(invoices)}
 
     def invoices_to_convert(self):
-        invoices = Invoice.objects.waiting_to_convert()
+        invoices = Invoice.objects.waiting_to_convert().select_related("project")
         return {
             "count": invoices.count(),
             "table": InvoiceDashboardTable(invoices),

--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -71,8 +71,32 @@ class MyFlaggedMixin:
         )
 
 
-class AdminDashboardView(MyFlaggedMixin, TemplateView):
+class PAFReviewMixin:
+    paf_reviewer_role = None  # set to a user attribute e.g. "is_apply_staff"
+
+    def paf_for_review(self):
+        if not getattr(self.request.user, self.paf_reviewer_role, False):
+            return {"count": None, "table": None}
+        project_settings = ProjectSettings.for_request(self.request)
+        paf_approvals = list(
+            get_paf_for_review(
+                user=self.request.user,
+                is_paf_approval_sequential=project_settings.paf_approval_sequential,
+            )
+        )
+        paf_table = PAFForReviewDashboardTable(
+            paf_approvals, prefix="paf-review-", order_by="-date_requested"
+        )
+        RequestConfig(self.request, paginate=False).configure(paf_table)
+        return {
+            "count": len(paf_approvals),
+            "table": paf_table,
+        }
+
+
+class AdminDashboardView(PAFReviewMixin, MyFlaggedMixin, TemplateView):
     template_name = "dashboard/staff_dashboard.html"
+    paf_reviewer_role = "is_apply_staff"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -97,25 +121,6 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
 
         return context
 
-    def paf_for_review(self):
-        if not self.request.user.is_apply_staff:
-            return {"count": None, "table": None}
-        project_settings = ProjectSettings.for_request(self.request)
-
-        paf_approvals = get_paf_for_review(
-            user=self.request.user,
-            is_paf_approval_sequential=project_settings.paf_approval_sequential,
-        )
-        paf_table = PAFForReviewDashboardTable(
-            paf_approvals, prefix="paf-review-", order_by="-date_requested"
-        )
-        RequestConfig(self.request, paginate=False).configure(paf_table)
-
-        return {
-            "count": paf_approvals.count(),
-            "table": paf_table,
-        }
-
     def my_tasks(self):
         tasks = render_task_templates_for_user(self.request, self.request.user)
         return {
@@ -137,7 +142,7 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
         }
 
     def active_invoices(self):
-        invoices = (
+        invoices = list(
             Invoice.objects.filter(
                 project__lead=self.request.user,
             )
@@ -146,7 +151,7 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
         )
 
         return {
-            "count": invoices.count(),
+            "count": len(invoices),
             "table": InvoiceDashboardTable(invoices),
         }
 
@@ -158,12 +163,13 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
         )
 
         limit = 10
+        projects_count = projects.count()
 
         return {
-            "count": projects.count(),
+            "count": projects_count,
             "filterset": filterset,
             "table": ProjectsDashboardTable(data=projects[:limit], prefix="project-"),
-            "display_more": projects.count() > limit,
+            "display_more": projects_count > limit,
             "url": reverse("apply:projects:all"),
         }
 
@@ -182,8 +188,9 @@ class AdminDashboardView(MyFlaggedMixin, TemplateView):
         }
 
 
-class FinanceDashboardView(MyFlaggedMixin, TemplateView):
+class FinanceDashboardView(PAFReviewMixin, MyFlaggedMixin, TemplateView):
     template_name = "dashboard/finance_dashboard.html"
+    paf_reviewer_role = "is_finance"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -200,25 +207,6 @@ class FinanceDashboardView(MyFlaggedMixin, TemplateView):
 
         return context
 
-    def paf_for_review(self):
-        if not self.request.user.is_finance:
-            return {"count": None, "table": None}
-        project_settings = ProjectSettings.for_request(self.request)
-
-        paf_approvals = get_paf_for_review(
-            user=self.request.user,
-            is_paf_approval_sequential=project_settings.paf_approval_sequential,
-        )
-        paf_table = PAFForReviewDashboardTable(
-            paf_approvals, prefix="paf-review-", order_by="-date_requested"
-        )
-        RequestConfig(self.request, paginate=False).configure(paf_table)
-
-        return {
-            "count": paf_approvals.count(),
-            "table": paf_table,
-        }
-
     def my_tasks(self):
         tasks = render_task_templates_for_user(self.request, self.request.user)
         return {
@@ -227,22 +215,20 @@ class FinanceDashboardView(MyFlaggedMixin, TemplateView):
         }
 
     def active_invoices(self):
-        invoices = Invoice.objects.for_finance_1().select_related("project")
-
+        invoices = list(Invoice.objects.for_finance_1().select_related("project"))
         return {
-            "count": invoices.count(),
+            "count": len(invoices),
             "table": InvoiceDashboardTable(invoices),
         }
 
     def invoices_for_approval(self):
-        invoices = Invoice.objects.approved_by_staff().select_related("project")
-
-        return {"count": invoices.count(), "table": InvoiceDashboardTable(invoices)}
+        invoices = list(Invoice.objects.approved_by_staff().select_related("project"))
+        return {"count": len(invoices), "table": InvoiceDashboardTable(invoices)}
 
     def invoices_to_convert(self):
-        invoices = Invoice.objects.waiting_to_convert().select_related("project")
+        invoices = list(Invoice.objects.waiting_to_convert().select_related("project"))
         return {
-            "count": invoices.count(),
+            "count": len(invoices),
             "table": InvoiceDashboardTable(invoices),
         }
 
@@ -306,8 +292,9 @@ class ReviewerDashboardView(MyFlaggedMixin, MySubmissionContextMixin, TemplateVi
         }
 
 
-class ContractingDashboardView(MyFlaggedMixin, TemplateView):
+class ContractingDashboardView(PAFReviewMixin, MyFlaggedMixin, TemplateView):
     template_name = "dashboard/contracting_dashboard.html"
+    paf_reviewer_role = "is_contracting"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -320,25 +307,6 @@ class ContractingDashboardView(MyFlaggedMixin, TemplateView):
         )
 
         return context
-
-    def paf_for_review(self):
-        if not self.request.user.is_contracting:
-            return {"count": None, "table": None}
-        project_settings = ProjectSettings.for_request(self.request)
-
-        paf_approvals = get_paf_for_review(
-            user=self.request.user,
-            is_paf_approval_sequential=project_settings.paf_approval_sequential,
-        )
-        paf_table = PAFForReviewDashboardTable(
-            paf_approvals, prefix="paf-review-", order_by="-date_requested"
-        )
-        RequestConfig(self.request, paginate=False).configure(paf_table)
-
-        return {
-            "count": paf_approvals.count(),
-            "table": paf_table,
-        }
 
     def my_tasks(self):
         tasks = render_task_templates_for_user(self.request, self.request.user)
@@ -361,22 +329,22 @@ class ContractingDashboardView(MyFlaggedMixin, TemplateView):
                 },
             }
         projects_in_contracting = Project.objects.in_contracting()
-        waiting_for_contract = projects_in_contracting.filter(
-            contracts__isnull=True
-        ).for_table()
-        waiting_for_contract_approval = projects_in_contracting.filter(
-            contracts__isnull=False
-        ).for_table()
+        waiting_for_contract = list(
+            projects_in_contracting.filter(contracts__isnull=True).for_table()
+        )
+        waiting_for_contract_approval = list(
+            projects_in_contracting.filter(contracts__isnull=False).for_table()
+        )
         return {
-            "count": projects_in_contracting.count(),
+            "count": len(waiting_for_contract) + len(waiting_for_contract_approval),
             "waiting_for_contract": {
-                "count": waiting_for_contract.count(),
+                "count": len(waiting_for_contract),
                 "table": ProjectsDashboardTable(
                     data=waiting_for_contract, prefix="project-waiting-contract-"
                 ),
             },
             "waiting_for_contract_approval": {
-                "count": waiting_for_contract_approval.count(),
+                "count": len(waiting_for_contract_approval),
                 "table": ProjectsDashboardTable(
                     data=waiting_for_contract_approval,
                     prefix="project-waiting-approval-",
@@ -448,26 +416,26 @@ class ApplicantDashboardView(TemplateView):
         }
 
     def active_invoices(self):
-        active_invoices = (
+        active_invoices = list(
             Invoice.objects.filter(project__user=self.request.user)
             .exclude(status__in=[PAID, DECLINED])
             .order_by("-requested_at")
         )
-        return {"count": active_invoices.count(), "data": active_invoices}
+        return {"count": len(active_invoices), "data": active_invoices}
 
     def historical_project_data(self):
-        historical_projects = (
+        historical_projects = list(
             Project.objects.filter(user=self.request.user).complete().for_table()
         )
         return {
-            "count": historical_projects.count(),
+            "count": len(historical_projects),
             "table": ProjectsDashboardTable(
                 data=historical_projects, prefix="past-project-"
             ),
         }
 
     def historical_submission_data(self):
-        historical_submissions = (
+        historical_submissions = list(
             ApplicationSubmission.objects.filter(
                 user=self.request.user,
             )
@@ -476,8 +444,7 @@ class ApplicantDashboardView(TemplateView):
             .for_table(self.request.user)
         )
         return {
-            "count": historical_submissions.count(),
-            "submissions": historical_submissions,
+            "count": len(historical_submissions),
             "table": SubmissionsTable(data=historical_submissions),
         }
 

--- a/hypha/apply/dashboard/views.py
+++ b/hypha/apply/dashboard/views.py
@@ -361,13 +361,13 @@ class CommunityDashboardView(MySubmissionContextMixin, TemplateView):
         submissions = ApplicationSubmission.objects.all().for_table(self.request.user)
 
         # Submissions in community review phase
-        my_community_review, my_community_review = self.my_community_review(
+        my_community_review_qs, my_community_review_table = self.my_community_review(
             self.request.user, submissions
         )
         context.update(
             {
-                "my_community_review": my_community_review,
-                "my_community_review_count": my_community_review.count(),
+                "my_community_review": my_community_review_table,
+                "my_community_review_count": my_community_review_qs.count(),
                 "my_reviewed": get_preview_context(
                     submissions.reviewed_by(self.request.user).order_by("-submit_time")
                 ),

--- a/hypha/apply/determinations/models.py
+++ b/hypha/apply/determinations/models.py
@@ -135,7 +135,7 @@ class Determination(DeterminationFormFieldsMixin, AccessFormData, models.Model):
     def get_absolute_url(self):
         return reverse(
             "apply:submissions:determinations:detail",
-            args=(self.submission.id, self.id),
+            args=(self.submission_id, self.id),
         )
 
     @property

--- a/hypha/apply/determinations/views.py
+++ b/hypha/apply/determinations/views.py
@@ -197,7 +197,7 @@ class BatchDeterminationCreateView(BaseStreamForm, CreateView):
         submissions = self.get_submissions()
         response = super().form_valid(form)
         determinations = {
-            determination.submission.id: determination
+            determination.submission_id: determination
             for determination in form.instances
         }
         sources = submissions.filter(id__in=list(determinations))

--- a/hypha/apply/funds/files.py
+++ b/hypha/apply/funds/files.py
@@ -30,12 +30,12 @@ class PrivateStreamFieldFile(StreamFieldFile):
         if isinstance(self.instance, ApplicationRevision) or isinstance(
             self.instance, Project
         ):
-            entity_id = self.instance.submission.pk
+            entity_id = self.instance.submission_id
         elif isinstance(self.instance, Report) or isinstance(self.instance, ProjectSOW):
-            entity_id = self.instance.project.submission.pk
+            entity_id = self.instance.project.submission_id
         elif isinstance(self.instance, ReportVersion):
             # Reports are project documents.
-            entity_id = self.instance.report.project.submission.pk
+            entity_id = self.instance.report.project.submission_id
         return entity_id
 
     def generate_filename(self):

--- a/hypha/apply/funds/models/application_revisions.py
+++ b/hypha/apply/funds/models/application_revisions.py
@@ -51,7 +51,7 @@ class ApplicationRevision(BaseStreamForm, AccessFormData, models.Model):
         return reverse(
             "funds:submissions:revisions:compare",
             kwargs={
-                "submission_pk": self.submission.id,
+                "submission_pk": self.submission_id,
                 "to": self.id,
                 "from": previous_revision.id,
             },

--- a/hypha/apply/funds/models/application_revisions.py
+++ b/hypha/apply/funds/models/application_revisions.py
@@ -39,8 +39,8 @@ class ApplicationRevision(BaseStreamForm, AccessFormData, models.Model):
         return reverse(
             "funds:submissions:revisions:compare",
             kwargs={
-                "submission_pk": self.submission.id,
-                "to": self.submission.live_revision.id,
+                "submission_pk": self.submission_id,
+                "to": self.submission.live_revision_id,
                 "from": self.id,
             },
         )

--- a/hypha/apply/funds/models/mixins.py
+++ b/hypha/apply/funds/models/mixins.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from functools import cached_property
 
 from django.core.files import File
 from django.utils.safestring import mark_safe
@@ -244,7 +245,7 @@ class AccessFormData:
             elif isinstance(field.block, FormFieldBlock):
                 yield field_id
 
-    @property
+    @cached_property
     def raw_fields(self):
         # Field ids to field class mapping - similar to raw_data
         return {field.id: field for field in self.form_fields}
@@ -258,7 +259,7 @@ class AccessFormData:
             fields[field_name] = response
         return fields
 
-    @property
+    @cached_property
     def named_blocks(self):
         return {
             field.block.name: field.id

--- a/hypha/apply/funds/models/mixins.py
+++ b/hypha/apply/funds/models/mixins.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-from functools import cached_property
 
 from django.core.files import File
 from django.utils.safestring import mark_safe
@@ -245,7 +244,7 @@ class AccessFormData:
             elif isinstance(field.block, FormFieldBlock):
                 yield field_id
 
-    @cached_property
+    @property
     def raw_fields(self):
         # Field ids to field class mapping - similar to raw_data
         return {field.id: field for field in self.form_fields}
@@ -259,7 +258,7 @@ class AccessFormData:
             fields[field_name] = response
         return fields
 
-    @cached_property
+    @property
     def named_blocks(self):
         return {
             field.block.name: field.id

--- a/hypha/apply/funds/models/submissions.py
+++ b/hypha/apply/funds/models/submissions.py
@@ -247,6 +247,7 @@ class ApplicationSubmissionQueryset(JSONOrderable):
                 "previous__lead",
             )
             .prefetch_related("screening_statuses")
+            .defer("search_data", "search_document")
         )
 
 

--- a/hypha/apply/funds/views/co_applicants.py
+++ b/hypha/apply/funds/views/co_applicants.py
@@ -203,7 +203,7 @@ class CoApplicantInviteAcceptView(View):
 
     def get_success_url(self):
         return reverse_lazy(
-            "apply:submissions:detail", args=(self.invite.submission.pk,)
+            "apply:submissions:detail", args=(self.invite.submission_id,)
         )
 
 

--- a/hypha/apply/funds/views/revisions.py
+++ b/hypha/apply/funds/views/revisions.py
@@ -59,9 +59,14 @@ class RevisionListView(ListView):
             An [`ApplicationRevision`][hypha.apply.funds.models.ApplicationRevision] QuerySet
         """
         self.submission = get_object_or_404(
-            ApplicationSubmission, id=self.kwargs["submission_pk"]
+            ApplicationSubmission.objects.defer("form_data"),
+            id=self.kwargs["submission_pk"],
         )
-        self.queryset = get_revisions(submission=self.submission)
+        self.queryset = (
+            get_revisions(submission=self.submission)
+            .select_related("author", "submission")
+            .defer("form_data", "submission__form_data")
+        )
 
         return super().get_queryset()
 

--- a/hypha/apply/funds/views/submission_detail.py
+++ b/hypha/apply/funds/views/submission_detail.py
@@ -53,6 +53,11 @@ class AdminSubmissionDetailView(ActivityContextMixin, DetailView):
     template_name_suffix = "_admin_detail"
     model = ApplicationSubmission
 
+    def get_object(self, queryset=None):
+        if not hasattr(self, "_object_cache"):
+            self._object_cache = super().get_object(queryset)
+        return self._object_cache
+
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
         if submission.status == DRAFT_STATE and not submission.can_view_draft(
@@ -114,6 +119,11 @@ class ReviewerSubmissionDetailView(ActivityContextMixin, DetailView):
     template_name_suffix = "_reviewer_detail"
     model = ApplicationSubmission
 
+    def get_object(self, queryset=None):
+        if not hasattr(self, "_object_cache"):
+            self._object_cache = super().get_object(queryset)
+        return self._object_cache
+
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
         # If the requesting user submitted the application, return the Applicant view.
@@ -147,6 +157,11 @@ class CommunitySubmissionDetailView(ActivityContextMixin, DetailView):
     template_name_suffix = "_community_detail"
     model = ApplicationSubmission
 
+    def get_object(self, queryset=None):
+        if not hasattr(self, "_object_cache"):
+            self._object_cache = super().get_object(queryset)
+        return self._object_cache
+
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()
         permission, _ = has_permission(
@@ -172,7 +187,9 @@ class ApplicantSubmissionDetailView(ActivityContextMixin, DetailView):
     model = ApplicationSubmission
 
     def get_object(self):
-        return super().get_object().from_draft()
+        if not hasattr(self, "_object_cache"):
+            self._object_cache = super().get_object().from_draft()
+        return self._object_cache
 
     def dispatch(self, request, *args, **kwargs):
         submission = self.get_object()

--- a/hypha/apply/funds/views/submission_edit.py
+++ b/hypha/apply/funds/views/submission_edit.py
@@ -99,6 +99,13 @@ class BaseSubmissionEditView(UpdateView):
         context = self.get_context_data()
         return render(request, "funds/application_preview.html", context)
 
+    def get_object(self, queryset=None):
+        # Cache the object to avoid repeated DB queries + JSON deserialization
+        # (get_object is called in dispatch, subclass dispatch, and UpdateView.get/post)
+        if not hasattr(self, "_object_cache"):
+            self._object_cache = super().get_object(queryset)
+        return self._object_cache
+
     def dispatch(self, request, *args, **kwargs):
         permission, _ = has_permission(
             "submission_edit",
@@ -237,10 +244,9 @@ class BaseSubmissionEditView(UpdateView):
         instance = kwargs.pop("instance").from_draft()
         initial = instance.raw_data
         for field_id in instance.file_field_ids:
+            original_value = initial.get(field_id)
             initial.pop(field_id + "-uploads", False)
-            initial[field_id] = self.get_placeholder_file(
-                instance.raw_data.get(field_id)
-            )
+            initial[field_id] = self.get_placeholder_file(original_value)
         kwargs["initial"] = initial
         return kwargs
 

--- a/hypha/apply/projects/models/payment.py
+++ b/hypha/apply/projects/models/payment.py
@@ -267,7 +267,7 @@ class Invoice(models.Model):
     def get_absolute_url(self):
         return reverse(
             "apply:projects:invoice-detail",
-            kwargs={"pk": self.project.submission.id, "invoice_pk": self.pk},
+            kwargs={"pk": self.project.submission_id, "invoice_pk": self.pk},
         )
 
     @property
@@ -298,7 +298,7 @@ class SupportingDocument(models.Model):
         return reverse(
             "apply:projects:invoice-supporting-document",
             kwargs={
-                "pk": self.invoice.project.submission.id,
+                "pk": self.invoice.project.submission_id,
                 "invoice_pk": self.invoice.pk,
                 "file_pk": self.pk,
             },

--- a/hypha/apply/projects/models/project.py
+++ b/hypha/apply/projects/models/project.py
@@ -176,6 +176,7 @@ class ProjectQuerySet(models.QuerySet):
                 "submission__page",
                 "lead",
             )
+            .defer("form_data", "form_fields")
         )
 
     def for_reporting_table(self):

--- a/hypha/apply/projects/models/project.py
+++ b/hypha/apply/projects/models/project.py
@@ -453,7 +453,7 @@ class Project(BaseStreamForm, AccessFormData, models.Model):
         return False
 
     def get_absolute_url(self):
-        return reverse("funds:submissions:project", args=[self.submission.id])
+        return reverse("funds:submissions:project", args=[self.submission_id])
 
     @property
     def can_make_approval(self):
@@ -700,7 +700,7 @@ class Contract(models.Model):
 
     def get_absolute_url(self):
         return reverse(
-            "apply:projects:contract", args=[self.project.submission.id, self.pk]
+            "apply:projects:contract", args=[self.project.submission_id, self.pk]
         )
 
 

--- a/hypha/apply/projects/tables.py
+++ b/hypha/apply/projects/tables.py
@@ -28,7 +28,7 @@ class BaseInvoiceTable(tables.Table):
     invoice_number = tables.LinkColumn(
         "funds:projects:invoice-detail",
         verbose_name=_("Invoice #"),
-        args=[tables.utils.A("project__submission__pk"), tables.utils.A("pk")],
+        args=[tables.utils.A("project__submission_id"), tables.utils.A("pk")],
         attrs={
             "td": {
                 "class": "js-title",  # using title as class because of batch-actions.js
@@ -50,7 +50,7 @@ class BaseInvoiceTable(tables.Table):
     class Meta:
         row_attrs = {
             "onclick": lambda record: (
-                f"window.location.href='{reverse('funds:projects:invoice-detail', args=[record.project.submission.pk, record.pk])}'"
+                f"window.location.href='{reverse('funds:projects:invoice-detail', args=[record.project.submission_id, record.pk])}'"
             ),
             "class": "table-row-link",
             "role": "button",

--- a/hypha/apply/projects/views/payment.py
+++ b/hypha/apply/projects/views/payment.py
@@ -585,6 +585,9 @@ class InvoiceListView(SingleTableMixin, FilterView, DelegateableListView):
     table_class = AdminInvoiceListTable
     template_name = "application_projects/invoice_list.html"
 
+    def get_queryset(self):
+        return super().get_queryset().select_related("project", "project__user")
+
     def get_table_class(self):
         if self.request.user.is_finance:
             return FinanceInvoiceTable

--- a/hypha/apply/projects/views/payment.py
+++ b/hypha/apply/projects/views/payment.py
@@ -372,7 +372,7 @@ class EditInvoiceView(InvoiceAccessMixin, UpdateView):
         if "delete" in form.data:
             return redirect(
                 "apply:projects:invoice-delete",
-                pk=self.object.project.submission.id,
+                pk=self.object.project.submission_id,
                 invoice_pk=self.object.id,
             )
         if form.is_valid():

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -1995,7 +1995,7 @@ class ProjectDetailDownloadView(ProjectBySubmissionIdMixin, SingleObjectMixin, V
         context["submission"] = self.object.submission
         context["submission_link"] = self.request.build_absolute_uri(
             reverse(
-                "apply:submissions:detail", kwargs={"pk": self.object.submission.id}
+                "apply:submissions:detail", kwargs={"pk": self.object.submission_id}
             )
         )
         context["supporting_documents"] = self.get_supporting_documents(self.object)
@@ -2022,7 +2022,7 @@ class ProjectDetailDownloadView(ProjectBySubmissionIdMixin, SingleObjectMixin, V
             documents_dict[packet_file.title] = self.request.build_absolute_uri(
                 reverse(
                     "apply:projects:document",
-                    kwargs={"pk": project.submission.id, "file_pk": packet_file.id},
+                    kwargs={"pk": project.submission_id, "file_pk": packet_file.id},
                 )
             )
         return documents_dict

--- a/hypha/apply/projects/views/project.py
+++ b/hypha/apply/projects/views/project.py
@@ -1627,6 +1627,11 @@ class UpdatePAFApproversView(View):
 
 
 class BaseProjectDetailView(ReportingMixin, ProjectBySubmissionIdMixin, DetailView):
+    def get_object(self, queryset=None):
+        if not hasattr(self, "_object_cache"):
+            self._object_cache = super().get_object()
+        return self._object_cache
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["statuses"] = get_project_status_choices()

--- a/hypha/apply/review/models.py
+++ b/hypha/apply/review/models.py
@@ -199,7 +199,7 @@ class Review(ReviewFormFieldsMixin, BaseStreamForm, AccessFormData, models.Model
         return reverse(
             "apply:submissions:reviews:review",
             args=(
-                self.submission.pk,
+                self.submission_id,
                 self.id,
             ),
         )

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -375,7 +375,7 @@ class ReviewOpinionFormView(UserPassesTestMixin, CreateView):
         if opinion.opinion == DISAGREE:
             return HttpResponseRedirect(
                 reverse_lazy(
-                    "apply:submissions:reviews:form", args=(self.review.submission.pk,)
+                    "apply:submissions:reviews:form", args=(self.review.submission_id,)
                 )
             )
         else:

--- a/hypha/apply/review/views.py
+++ b/hypha/apply/review/views.py
@@ -116,7 +116,7 @@ class ReviewEditView(UserPassesTestMixin, BaseStreamForm, UpdateView):
 
     def get_success_url(self):
         review = self.get_object()
-        return reverse_lazy("funds:submissions:detail", args=(review.submission.id,))
+        return reverse_lazy("funds:submissions:detail", args=(review.submission_id,))
 
 
 @method_decorator(login_required, name="dispatch")
@@ -306,7 +306,7 @@ class ReviewDisplay(UserPassesTestMixin, DetailView):
         if review.is_draft:
             return HttpResponseRedirect(
                 reverse_lazy(
-                    "apply:submissions:reviews:form", args=(review.submission.id,)
+                    "apply:submissions:reviews:form", args=(review.submission_id,)
                 )
             )
 
@@ -513,7 +513,7 @@ class ReviewDeleteView(UserPassesTestMixin, DeleteView):
 
     def get_success_url(self):
         review = self.get_object()
-        return reverse_lazy("funds:submissions:detail", args=(review.submission.id,))
+        return reverse_lazy("funds:submissions:detail", args=(review.submission_id,))
 
 
 @method_decorator(login_required, name="dispatch")
@@ -540,4 +540,4 @@ class ReviewOpinionDeleteView(DeleteView):
 
     def get_success_url(self):
         review = self.review_opinion.review
-        return reverse_lazy("funds:submissions:detail", args=(review.submission.id,))
+        return reverse_lazy("funds:submissions:detail", args=(review.submission_id,))

--- a/hypha/apply/users/tokens.py
+++ b/hypha/apply/users/tokens.py
@@ -108,5 +108,5 @@ class CoApplicantInviteTokenGenerator(PasswordlessLoginTokenGenerator):
         attempts using the reset token, provided the secret isn't compromised.
         """
         return (
-            f"{invite.pk}{invite.submission.pk}{timestamp}{invite.invited_user_email}"
+            f"{invite.pk}{invite.submission_id}{timestamp}{invite.invited_user_email}"
         )


### PR DESCRIPTION
Fixes #4520

This are not dramatic changes but many small things adds up. In testing the savings are small but I think that on large live environments they can be noticeable.

* Defer loading to have fields like search_data, search_document, form_data and form_fields only load when needed.
* Use submission_id instead of submission.id to avoid a db query when the model is not loaded/needed.
* Implement select_related() to avoid N+1 queries.
* Cache get_object() so it is not loaded multiple times in one request.