### PR TITLE
Update the hook system to use Python 3 and Django 5 patterns

### DIFF
--- a/docs/references/template-hooks.md
+++ b/docs/references/template-hooks.md
@@ -33,7 +33,7 @@ Creating a hook listener in a `third_party_app`:
 
     # Example 1
     def css_resources(context, *args, **kwargs):
-        return mark_safe(u'<link rel="stylesheet" href="%s/app_hook/styles.css">' % settings.STATIC_URL)
+        return mark_safe('<link rel="stylesheet" href="%s/app_hook/styles.css">' % settings.STATIC_URL)
 
 
     # Example 2
@@ -52,7 +52,8 @@ Creating a hook listener in a `third_party_app`:
         # If you are doing this a lot, make sure to keep your templates in memory (google: django.template.loaders.cached.Loader)
         return render_to_string(
             template_name='templates/app_hook/head_resources.html',
-            context_instance=context
+            context=dict(context),
+            request=context.get('request'),
         )
 
 
@@ -61,8 +62,8 @@ Creating a hook listener in a `third_party_app`:
         articles = Article.objects.all()
         return render_to_string(
             template_name='templates/app_hook/my_articles.html',
-            dictionary={'articles': articles, },
-            context_instance=context
+            context={'articles': articles},
+            request=context.get('request'),
         )
 
 Registering a hook listener in a `third_party_app`:
@@ -78,7 +79,7 @@ Registering a hook listener in a `third_party_app`:
         verbose_name = 'My App'
 
         def ready(self):
-            from hooks.templatehook import hook
+            from hypha.core.templatehook import hook
             from third_party_app.template_hooks import css_resources
 
             hook.register("within_head", css_resources)

--- a/docs/references/template-hooks.md
+++ b/docs/references/template-hooks.md
@@ -33,7 +33,7 @@ Creating a hook listener in a `third_party_app`:
 
     # Example 1
     def css_resources(context, *args, **kwargs):
-        return mark_safe(u'<link rel="stylesheet" href="%s/app_hook/styles.css">' % settings.STATIC_URL)
+        return mark_safe('<link rel="stylesheet" href="%s/app_hook/styles.css">' % settings.STATIC_URL)
 
 
     # Example 2
@@ -52,7 +52,8 @@ Creating a hook listener in a `third_party_app`:
         # If you are doing this a lot, make sure to keep your templates in memory (google: django.template.loaders.cached.Loader)
         return render_to_string(
             template_name='templates/app_hook/head_resources.html',
-            context_instance=context
+            context=context.flatten(),
+            request=context.get('request'),
         )
 
 
@@ -61,8 +62,8 @@ Creating a hook listener in a `third_party_app`:
         articles = Article.objects.all()
         return render_to_string(
             template_name='templates/app_hook/my_articles.html',
-            dictionary={'articles': articles, },
-            context_instance=context
+            context={'articles': articles},
+            request=context.get('request'),
         )
 
 Registering a hook listener in a `third_party_app`:
@@ -78,7 +79,7 @@ Registering a hook listener in a `third_party_app`:
         verbose_name = 'My App'
 
         def ready(self):
-            from hooks.templatehook import hook
+            from hypha.core.templatehook import hook
             from third_party_app.template_hooks import css_resources
 
             hook.register("within_head", css_resources)

--- a/hypha/core/templatehook.py
+++ b/hypha/core/templatehook.py
@@ -1,7 +1,7 @@
 # Adds the ability to have hooks injected into templates, via the `hooks_tags.hook` template tag.
 #
 # Originally from https://github.com/nitely/django-hooks but after culling everything except
-# the template hook.  See /docs/templatehook.rst for more information
+# the template hook.  See docs/references/template-hooks.md for more information
 #
 # The reason this was forked, rather than used as a module, is that the last commit from the
 # other project was made in 2015, and can no longer be imported into a modern django project.
@@ -9,17 +9,13 @@
 # so were removed.
 
 
-class TemplateHook(object):
+class TemplateHook:
     """
     A hook for templates. This can be used directly or\
     through the :py:class:`Hook` dispatcher
-
-    :param list providing_args: A list of the arguments\
-    this hook can pass along in a :py:func:`.__call__`
     """
 
-    def __init__(self, providing_args=None):
-        self.providing_args = providing_args or []
+    def __init__(self):
         self._registry = []
 
     def __call__(self, *args, **kwargs):
@@ -38,7 +34,8 @@ class TemplateHook(object):
 
         :param callable func: A function reference used as a callback
         """
-        assert callable(func), "Callback func must be a callable"
+        if not callable(func):
+            raise TypeError("Callback func must be a callable")
 
         self._registry.append(func)
 
@@ -58,10 +55,10 @@ class TemplateHook(object):
         """
         Remove all callbacks
         """
-        del self._registry[:]
+        self._registry.clear()
 
 
-class Hook(object):
+class Hook:
     """
     Dynamic dispatcher (proxy) for :py:class:`TemplateHook`
     """

--- a/hypha/core/templatetags/hooks_tags.py
+++ b/hypha/core/templatetags/hooks_tags.py
@@ -36,7 +36,7 @@ def template_hook_collect(module, hook_name, *args, **kwargs):
     Example::
 
         import myhooks
-        from hooks.templatetags import template_hook_collect
+        from hypha.core.templatetags.hooks_tags import template_hook_collect
 
         @register.simple_tag(takes_context=True)
         def hook(context, name, *args, **kwargs):

--- a/hypha/core/tests/test_templatehook.py
+++ b/hypha/core/tests/test_templatehook.py
@@ -43,12 +43,8 @@ class TestTemplateHook(SimpleTestCase):
         self.assertEqual(self.hook(), [])
 
     def test_register_non_callable_raises(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.hook.register("not_callable")
-
-    def test_providing_args_stored(self):
-        hook = TemplateHook(providing_args=["foo", "bar"])
-        self.assertEqual(hook.providing_args, ["foo", "bar"])
 
 
 class TestHook(SimpleTestCase):


### PR DESCRIPTION
## Test Steps

 - [ ] Confirm that existing plugins work as expected.