### PR TITLE
Do not use custom password field template for wagtail admin.

### DIFF
--- a/hypha/apply/users/forms.py
+++ b/hypha/apply/users/forms.py
@@ -102,6 +102,10 @@ class CustomUserAdminFormBase:
             attrs={"value": "Not used - see full_name"}
         )
 
+        for field_name in ("password1", "password2"):
+            if field_name in self.fields:
+                self.fields[field_name].widget.attrs["data_plain"] = True
+
 
 class GroupsModelMultipleChoiceField(forms.ModelMultipleChoiceField):
     """

--- a/hypha/templates/django/forms/widgets/password.html
+++ b/hypha/templates/django/forms/widgets/password.html
@@ -1,39 +1,45 @@
 {% load i18n %}
 
-<div class="input validator" x-data="{ showPassword: false }" x-id="['toggle-help']">
-    <input
-        type="{{ widget.type }}"
-        :type="showPassword ? 'text' : 'password'"
-        :autocomplete="showPassword ? 'off' : 'current-password'"
-        name="{{ widget.name }}"
-        {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
-        {% include 'django/forms/widgets/attrs.html' %}
-        :aria-describedby="$id('toggle-help')"
-    />
-    <div
-        class="opacity-50 cursor-pointer hover:opacity-80"
-        role="button"
-        tabindex="0"
-        :aria-label="showPassword ? '{% trans "Hide password" %}' : '{% trans "Show password" %}'"
-        x-bind:title="showPassword ? '{% trans "Hide password" %}' : '{% trans "Show password" %}'"
-        :aria-pressed="showPassword.toString()"
-        @click.prevent="showPassword = !showPassword"
-        @keydown.enter.prevent="showPassword = !showPassword"
-        @keydown.space.prevent="showPassword = !showPassword"
-    >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
-             fill="currentColor"
-             class="size-4"
-             aria-hidden="true"
+{% if widget.attrs.data_plain %}
+    {% include "django/forms/widgets/input.html" %}
+{% else %}
+    <div class="input validator" x-data="{ showPassword: false }" x-id="['toggle-help']">
+        <input
+            type="{{ widget.type }}"
+            :type="showPassword ? 'text' : 'password'"
+            :autocomplete="showPassword ? 'off' : 'current-password'"
+            name="{{ widget.name }}"
+            {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
+            {% include 'django/forms/widgets/attrs.html' %}
+            :aria-describedby="$id('toggle-help')"
+        />
+        <div
+            class="opacity-50 cursor-pointer hover:opacity-80"
+            role="button"
+            tabindex="0"
+            :aria-label="showPassword ? '{% trans "Hide password" %}' : '{% trans "Show password" %}'"
+            x-bind:title="showPassword ? '{% trans "Hide password" %}' : '{% trans "Show password" %}'"
+            :aria-pressed="showPassword.toString()"
+            @click.prevent="showPassword = !showPassword"
+            @keydown.enter.prevent="showPassword = !showPassword"
+            @keydown.space.prevent="showPassword = !showPassword"
         >
-            <path x-show="!showPassword" d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
-            <path x-show="!showPassword" fill-rule="evenodd" d="M1.38 8.28a.87.87 0 0 1 0-.566 7.003 7.003 0 0 1 13.238.006.87.87 0 0 1 0 .566A7.003 7.003 0 0 1 1.379 8.28ZM11 8a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" clip-rule="evenodd" />
-            <path x-show="showPassword" fill-rule="evenodd" d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l10.5 10.5a.75.75 0 1 0 1.06-1.06l-1.322-1.323a7.012 7.012 0 0 0 2.16-3.11.87.87 0 0 0 0-.567A7.003 7.003 0 0 0 4.82 3.76l-1.54-1.54Zm3.196 3.195 1.135 1.136A1.502 1.502 0 0 1 9.45 8.389l1.136 1.135a3 3 0 0 0-4.109-4.109Z" clip-rule="evenodd" />
-            <path x-show="showPassword"  d="m7.812 10.994 1.816 1.816A7.003 7.003 0 0 1 1.38 8.28a.87.87 0 0 1 0-.566 6.985 6.985 0 0 1 1.113-2.039l2.513 2.513a3 3 0 0 0 2.806 2.806Z" />
-        </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
+                 fill="currentColor"
+                 width="16"
+                 height="16"
+                 class="size-4"
+                 aria-hidden="true"
+            >
+                <path x-show="!showPassword" d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
+                <path x-show="!showPassword" fill-rule="evenodd" d="M1.38 8.28a.87.87 0 0 1 0-.566 7.003 7.003 0 0 1 13.238.006.87.87 0 0 1 0 .566A7.003 7.003 0 0 1 1.379 8.28ZM11 8a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" clip-rule="evenodd" />
+                <path x-show="showPassword" fill-rule="evenodd" d="M3.28 2.22a.75.75 0 0 0-1.06 1.06l10.5 10.5a.75.75 0 1 0 1.06-1.06l-1.322-1.323a7.012 7.012 0 0 0 2.16-3.11.87.87 0 0 0 0-.567A7.003 7.003 0 0 0 4.82 3.76l-1.54-1.54Zm3.196 3.195 1.135 1.136A1.502 1.502 0 0 1 9.45 8.389l1.136 1.135a3 3 0 0 0-4.109-4.109Z" clip-rule="evenodd" />
+                <path x-show="showPassword"  d="m7.812 10.994 1.816 1.816A7.003 7.003 0 0 1 1.38 8.28a.87.87 0 0 1 0-.566 6.985 6.985 0 0 1 1.113-2.039l2.513 2.513a3 3 0 0 0 2.806 2.806Z" />
+            </svg>
 
-        <span :id="$id('toggle-help')" class="sr-only">
-            <span x-text="showPassword ? '{% trans "Password is currently visible" %}' : '{% trans "Password is currently hidden" %}'"></span>
-        </span>
+            <span :id="$id('toggle-help')" class="sr-only">
+                <span x-text="showPassword ? '{% trans "Password is currently visible" %}' : '{% trans "Password is currently hidden" %}'"></span>
+            </span>
+        </div>
     </div>
-</div>
+{% endif %}


### PR DESCRIPTION
Fixes #4844

Hypha has custom form field templates that overrides the standard Django ones. The password field template uses tailwind and alpine so does not work well in Wagtail admin. This PR ads a check and fallback on the standard Django template when used for some wagtail admin fields.

## Test Steps

 - [ ] Test that the password fields on Hypha user account page and elevate works as before.
 - [ ] Test that the password fields on wagtail admin user edit view looks and behave as they should, plain django style.

The Wagtail admin user password fields only show when `WAGTAILUSERS_PASSWORD_ENABLED = True`. Hypha default is `False`