### PR TITLE
Replace author `Edit` button with new window link icon

### DIFF
--- a/hypha/apply/funds/templates/funds/includes/rendered_answers.html
+++ b/hypha/apply/funds/templates/funds/includes/rendered_answers.html
@@ -51,8 +51,8 @@
                 <dd class="flex gap-1 items-center">
                     {{ object.get_full_name_display }}
                     {% if request.user.is_apply_staff %}
-                        <a class="link" href="{% url 'wagtailusers_users:edit' object.user_id %}" target="_blank">
-                            {% heroicon_mini "arrow-top-right-on-square" class="inline align-text-bottom size-4" %}
+                        <a class="link" title="{% trans 'Edit user account' %}" href="{% url 'wagtailusers_users:edit' object.user_id %}" target="_blank">
+                            {% heroicon_mini "arrow-top-right-on-square" class="inline align-text-bottom size-4" aria_hidden=true %}
                         </a>
                     {% endif %}
                 </dd>

--- a/hypha/apply/funds/templates/funds/includes/rendered_answers.html
+++ b/hypha/apply/funds/templates/funds/includes/rendered_answers.html
@@ -48,11 +48,11 @@
         {% if object|show_applicant_identity:request.user %}
             <div class="fieldset">
                 <dt class="font-semibold">{% trans "Legal Name" %}</dt>
-                <dd class="flex gap-2 items-center">
+                <dd class="flex gap-1 items-center">
                     {{ object.get_full_name_display }}
                     {% if request.user.is_apply_staff %}
-                        <a class="link" href="{% url 'wagtailusers_users:edit' object.user_id %}">
-                            {% trans "Edit" %}
+                        <a class="link" href="{% url 'wagtailusers_users:edit' object.user_id %}" target="_blank">
+                            {% heroicon_mini "arrow-top-right-on-square" class="inline align-text-bottom size-4" %}
                         </a>
                     {% endif %}
                 </dd>


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Addressing the conversation [here](https://github.com/HyphaApp/hypha/pull/4380#issuecomment-4491706335). Making the link to the user's wagtail admin page a little less confusing now that the "Change Author" feature exists. Also made this open in a new tab. Feels a bit more intuitive 

*before*
<img width="160" height="92" alt="Screenshot 2026-05-21 at 09 52 43" src="https://github.com/user-attachments/assets/164f4523-983a-4ee5-9ed2-8c7bbfab9de5" />
*after*
<img width="160" height="92" alt="Screenshot 2026-05-21 at 09 51 55" src="https://github.com/user-attachments/assets/afa00bac-e232-464a-bd8c-2ae54e5970d5" />