### PR TITLE
Added upload (and debug) to whitelisted URLs

### DIFF
--- a/hypha/apply/users/middleware.py
+++ b/hypha/apply/users/middleware.py
@@ -19,7 +19,11 @@ TWO_FACTOR_EXEMPTED_PATH_PREFIXES = [
     "/logout/",
     "/account/",
     "/apply/submissions/success/",
+    "/upload/upload/",
 ]
+
+if settings.DEBUG:
+    TWO_FACTOR_EXEMPTED_PATH_PREFIXES.append("/__debug__/")
 
 
 def get_page_path(wagtail_page):

--- a/hypha/apply/users/tests/test_middleware.py
+++ b/hypha/apply/users/tests/test_middleware.py
@@ -41,8 +41,11 @@ class TestTwoFactorAuthenticationMiddleware(TestCase):
             if "success" in path:
                 submission = ApplicationSubmissionFactory()
                 path = str(path) + f"{submission.id}/"
-            if "logout" in path:
+                response = self.client.get(path, follow=True)
+            elif "upload" in path:
+                response = self.client.post(path, HTTP_TUS_RESUMABLE=True)
+            elif "logout" in path:
                 response = self.client.post(path, follow=True)
             else:
                 response = self.client.get(path, follow=True)
-            self.assertEqual(response.status_code, 200)
+            self.assertIn(response.status_code, [200, 201])


### PR DESCRIPTION
<!--
Thanks for contributing to Hypha!

Please ensure your contributions pass all necessary linting/testing and that the appropriate documentation has been updated.
-->

<!--
Describe briefly what your pull request changes. If this is resolving an issue, please specify below via "Fixes #<Github Issue ID>"
-->
Fixes #4857, adds the upload URL prefix to whitelisted URLs to allow for uploading of files to complete a submission without needing to do 2FA. (also added `/__debug__/` as the toolbars were failing to load)


## Test Steps
<!-- 
If step does not require manual testing, skip/remove this section.

Give a brief overview of the steps required for a user/dev to test this contribution. Important things to include:
 - Required user roles for where necessary (ie. "As a Staff Admin...")
 - Clear & validatable expected results (ie. "Confirm the submit button is now not clickable")
 - Language that can be understood by non-technical testers if being tested by users
-->

 - [ ] With both `ENFORCE_TWO_FACTOR=True` and `FORCE_LOGIN_FOR_APPLICATION=True`, ensure uploading a file as a user without 2FA enabled works as expected.