### PR TITLE
Avoid having comments partial load twise.

### DIFF
--- a/hypha/apply/funds/templates/funds/comments.html
+++ b/hypha/apply/funds/templates/funds/comments.html
@@ -103,7 +103,7 @@
             class="comments"
             id="comment-feed"
             hx-get="{% url 'activity:partial-comments' object.id %}"
-            hx-trigger="load, intersect once"
+            hx-trigger="load"
         >
             <p>{% trans "Loading…" %}</p>
         </section>


### PR DESCRIPTION
Comments partial had `hx-trigger="load, intersect once"`. This PR removes `, intersect once`.

Looks like `, intersect once` was a leftover that we missed to remove at some point. It causes the comment partial to load twice on each page load for no reason.