### PR TITLE
Use elevate for adding and deleting passkeys

### DIFF
--- a/hypha/apply/users/passkey_views.py
+++ b/hypha/apply/users/passkey_views.py
@@ -68,10 +68,10 @@ def passkey_elevate_required(view_func):
     passkey management actions — adding and removing passkeys.
 
     This mirrors the elevation gate used for disabling 2FA and changing the
-    account email: a user with a usable password must confirm it again before
-    the action is allowed. Users without a usable password (e.g. OAuth logins)
-    have no password to re-confirm and are let through, matching the behaviour
-    of ``account_email_change``.
+    account email. All users must re-authenticate before the action is allowed:
+    users with a usable password confirm it again, while users without one
+    (e.g. OAuth logins) are routed to the same elevate page where they confirm
+    access via an emailed one-time code.
 
     These endpoints are called via ``fetch`` (registration) and HTMX (delete),
     so instead of returning a normal redirect we hand the client the elevate
@@ -81,7 +81,7 @@ def passkey_elevate_required(view_func):
 
     @wraps(view_func)
     def _wrapped(request, *args, **kwargs):
-        if request.user.has_usable_password() and not request.is_elevated():
+        if not request.is_elevated():
             elevate_url = redirect_to_elevate(resolve_url("users:account"))["Location"]
             if request.headers.get("HX-Request"):
                 response = HttpResponse(status=204)

--- a/hypha/apply/users/passkey_views.py
+++ b/hypha/apply/users/passkey_views.py
@@ -8,7 +8,7 @@ from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.http import Http404, JsonResponse
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render, resolve_url
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -36,6 +36,8 @@ from webauthn.helpers.structs import (
     UserVerificationRequirement,
 )
 
+from hypha.elevate.views import redirect_to_elevate
+
 from .models import Passkey
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,36 @@ def passkeys_required(view_func):
     def _wrapped(request, *args, **kwargs):
         if not passkeys_enabled():
             raise Http404
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped
+
+
+def passkey_elevate_required(view_func):
+    """Require an elevated (recently re-authenticated) session for sensitive
+    passkey management actions — adding and removing passkeys.
+
+    This mirrors the elevation gate used for disabling 2FA and changing the
+    account email: a user with a usable password must confirm it again before
+    the action is allowed. Users without a usable password (e.g. OAuth logins)
+    have no password to re-confirm and are let through, matching the behaviour
+    of ``account_email_change``.
+
+    These endpoints are called via ``fetch`` (registration) and HTMX (delete),
+    so instead of returning a normal redirect we hand the client the elevate
+    URL: an ``HX-Redirect`` header for HTMX requests, otherwise a JSON body with
+    an ``elevate_url`` the JavaScript can navigate to.
+    """
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if request.user.has_usable_password() and not request.is_elevated():
+            elevate_url = redirect_to_elevate(resolve_url("users:account"))["Location"]
+            if request.headers.get("HX-Request"):
+                response = HttpResponse(status=204)
+                response["HX-Redirect"] = elevate_url
+                return response
+            return JsonResponse({"elevate_url": elevate_url}, status=403)
         return view_func(request, *args, **kwargs)
 
     return _wrapped
@@ -111,6 +143,7 @@ MAX_PASSKEYS_PER_USER = 10
 @passkeys_required
 @login_required
 @require_POST
+@passkey_elevate_required
 @ratelimit(key="user", rate=settings.DEFAULT_RATE_LIMIT, method="POST")
 def passkey_register_begin(request):
     user = request.user
@@ -149,6 +182,7 @@ def passkey_register_begin(request):
 @passkeys_required
 @login_required
 @require_POST
+@passkey_elevate_required
 @ratelimit(key="user", rate=settings.DEFAULT_RATE_LIMIT, method="POST")
 def passkey_register_complete(request):
     try:
@@ -348,6 +382,7 @@ def passkey_list(request):
 @passkeys_required
 @login_required
 @require_POST
+@passkey_elevate_required
 def passkey_delete(request, pk):
     passkey = get_object_or_404(Passkey, pk=pk, user=request.user)
     logger.info(

--- a/hypha/apply/users/passkey_views.py
+++ b/hypha/apply/users/passkey_views.py
@@ -39,18 +39,13 @@ from webauthn.helpers.structs import (
 from hypha.elevate.views import redirect_to_elevate
 
 from .models import Passkey
+from .services import send_passkey_notification
+from .utils import passkeys_enabled
 
 logger = logging.getLogger(__name__)
 
 SESSION_CHALLENGE_KEY_REGISTER = "webauthn_challenge_register"
 SESSION_CHALLENGE_KEY_AUTH = "webauthn_challenge_auth"
-
-
-def passkeys_enabled() -> bool:
-    """Passkeys require WEBAUTHN_RP_ID in production. In DEBUG (local/dev)
-    we fall back to the request host so the feature can be exercised locally.
-    """
-    return bool(getattr(settings, "WEBAUTHN_RP_ID", None)) or settings.DEBUG
 
 
 def passkeys_required(view_func):
@@ -252,6 +247,7 @@ def passkey_register_complete(request):
         )
         return JsonResponse({"error": _("Could not save passkey")}, status=500)
     logger.info("Passkey registered for user %s (name=%r)", request.user.pk, name)
+    send_passkey_notification(request, request.user, name, added=True)
     return JsonResponse({"status": "ok"})
 
 
@@ -402,7 +398,9 @@ def passkey_delete(request, pk):
         pk,
         passkey.name,
     )
+    passkey_name = passkey.name
     passkey.delete()
+    send_passkey_notification(request, request.user, passkey_name, added=False)
     passkeys = request.user.passkeys.all()
     return render(request, "users/partials/passkey-list.html", {"passkeys": passkeys})
 

--- a/hypha/apply/users/passkey_views.py
+++ b/hypha/apply/users/passkey_views.py
@@ -112,15 +112,26 @@ def _get_origin(request):
     return f"{scheme}://{request.get_host()}"
 
 
+# WebAuthn challenges are single-use, but they should also be short-lived.
+# Reject any challenge older than this to match spec guidance (a few minutes).
+CHALLENGE_TTL_SECONDS = 300
+
+
 def _store_challenge(request, challenge: bytes, key: str):
-    request.session[key] = base64.b64encode(challenge).decode()
+    request.session[key] = {
+        "challenge": base64.b64encode(challenge).decode(),
+        "created": timezone.now().timestamp(),
+    }
 
 
 def _load_challenge(request, key: str) -> bytes:
-    encoded = request.session.pop(key, None)
-    if not encoded:
+    stored = request.session.pop(key, None)
+    if not isinstance(stored, dict):
         raise PermissionDenied("No active WebAuthn challenge.")
-    return base64.b64decode(encoded)
+    created = stored.get("created")
+    if created is None or timezone.now().timestamp() - created > CHALLENGE_TTL_SECONDS:
+        raise PermissionDenied("WebAuthn challenge expired.")
+    return base64.b64decode(stored["challenge"])
 
 
 _VALID_TRANSPORTS = {t.value for t in AuthenticatorTransport}

--- a/hypha/apply/users/services.py
+++ b/hypha/apply/users/services.py
@@ -14,9 +14,51 @@ from hypha.core.mail import MarkdownMail
 
 from .models import PendingSignup
 from .tokens import PasswordlessLoginTokenGenerator, PasswordlessSignupTokenGenerator
-from .utils import get_redirect_url, get_user_by_email
+from .utils import get_redirect_url, get_user_by_email, local_event_time
 
 User = get_user_model()
+
+
+def send_passkey_notification(request, user, passkey_name, *, added):
+    """Notify the user by email that a passkey was added to or removed from
+    their account. Mirrors the login notification so the two feel consistent.
+
+    Args:
+        request: The current request (used for timezone and site resolution).
+        user: The user whose account changed.
+        passkey_name: Display name of the affected passkey.
+        added: True if the passkey was added, False if it was removed.
+    """
+    if not settings.SEND_MESSAGES or not user.email:
+        return
+
+    if added:
+        subject = _("A passkey was added to your %(org)s account") % {
+            "org": settings.ORG_LONG_NAME
+        }
+        template = "users/emails/passkey_added_notification.md"
+    else:
+        subject = _("A passkey was removed from your %(org)s account") % {
+            "org": settings.ORG_LONG_NAME
+        }
+        template = "users/emails/passkey_removed_notification.md"
+
+    if settings.EMAIL_SUBJECT_PREFIX:
+        subject = str(settings.EMAIL_SUBJECT_PREFIX) + str(subject)
+
+    email = MarkdownMail(template)
+    email.send(
+        to=user.email,
+        subject=subject,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        context={
+            "user": user,
+            "passkey_name": passkey_name,
+            "event_time": local_event_time(request),
+            "site": Site.find_for_request(request) if request else None,
+            "ORG_EMAIL": settings.ORG_EMAIL,
+        },
+    )
 
 
 class PasswordlessAuthService:

--- a/hypha/apply/users/signals.py
+++ b/hypha/apply/users/signals.py
@@ -1,13 +1,12 @@
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_in
 from django.dispatch import receiver
-from django.utils import formats, timezone
 from django.utils.translation import gettext_lazy as _
 from wagtail.models import Site
 
 from hypha.core.mail import MarkdownMail
 
-from .utils import get_zoneinfo
+from .utils import local_event_time
 
 HIJACK_VIEW_NAMES = {
     "hijack-become",
@@ -29,11 +28,6 @@ def send_login_notification(sender, request, user, **kwargs):
         if request.resolver_match.view_name in HIJACK_VIEW_NAMES:
             return
 
-    tz_name = (
-        getattr(request, "session", {}).get("user_timezone", "") if request else ""
-    )
-    user_tz = get_zoneinfo(tz_name)
-
     subject = _("Successful login to %(org)s") % {"org": settings.ORG_LONG_NAME}
     if settings.EMAIL_SUBJECT_PREFIX:
         subject = str(settings.EMAIL_SUBJECT_PREFIX) + str(subject)
@@ -45,12 +39,7 @@ def send_login_notification(sender, request, user, **kwargs):
         from_email=settings.DEFAULT_FROM_EMAIL,
         context={
             "user": user,
-            "login_time": "{} ({})".format(
-                formats.date_format(
-                    timezone.localtime(timezone=user_tz), "SHORT_DATETIME_FORMAT"
-                ),
-                tz_name or timezone.get_current_timezone_name(),
-            ),
+            "login_time": local_event_time(request),
             "site": Site.find_for_request(request) if request else None,
             "ORG_EMAIL": settings.ORG_EMAIL,
         },

--- a/hypha/apply/users/templates/elevate/elevate.html
+++ b/hypha/apply/users/templates/elevate/elevate.html
@@ -9,7 +9,7 @@
 
         <h2 class="text-2xl text-center">{% trans "Confirm access" %}</h2>
 
-        <p class="mb-4 text-center">
+        <p class="m-4 text-center">
             {% if request.user.full_name %}
                 {% blocktrans with name=request.user.full_name email=request.user.email trimmed %}
                     Signed in as <strong>{{ name }}({{ email }})</strong>

--- a/hypha/apply/users/templates/users/emails/passkey_added_notification.md
+++ b/hypha/apply/users/templates/users/emails/passkey_added_notification.md
@@ -1,0 +1,20 @@
+{% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
+{% blocktrans %}Dear {{ user }},{% endblocktrans %}
+
+{% blocktrans %}This is to notify you that a new passkey was added to your account at {{ ORG_LONG_NAME }}.{% endblocktrans %}
+
+{% blocktrans %}Passkey: {{ passkey_name }}{% endblocktrans %}
+{% blocktrans with event_time=event_time %}Added: {{ event_time }}{% endblocktrans %}
+
+{% blocktrans %}If you did not add this passkey, please contact us immediately and consider removing it from your account.{% endblocktrans %}
+
+{% if ORG_EMAIL %}
+{% blocktrans %}If you have any questions, please contact us at {{ ORG_EMAIL }}.{% endblocktrans %}
+{% endif %}
+
+{% blocktrans %}Kind Regards,
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
+
+--
+{{ ORG_LONG_NAME }}
+{% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/templates/users/emails/passkey_removed_notification.md
+++ b/hypha/apply/users/templates/users/emails/passkey_removed_notification.md
@@ -1,0 +1,20 @@
+{% load i18n wagtailadmin_tags %}{% base_url_setting as base_url %}
+{% blocktrans %}Dear {{ user }},{% endblocktrans %}
+
+{% blocktrans %}This is to notify you that a passkey was removed from your account at {{ ORG_LONG_NAME }}.{% endblocktrans %}
+
+{% blocktrans %}Passkey: {{ passkey_name }}{% endblocktrans %}
+{% blocktrans with event_time=event_time %}Removed: {{ event_time }}{% endblocktrans %}
+
+{% blocktrans %}If you did not remove this passkey, please contact us immediately and consider changing your password if you have one.{% endblocktrans %}
+
+{% if ORG_EMAIL %}
+{% blocktrans %}If you have any questions, please contact us at {{ ORG_EMAIL }}.{% endblocktrans %}
+{% endif %}
+
+{% blocktrans %}Kind Regards,
+The {{ ORG_SHORT_NAME }} Team{% endblocktrans %}
+
+--
+{{ ORG_LONG_NAME }}
+{% if site %}{{ site.root_url }}{% else %}{{ base_url }}{% endif %}

--- a/hypha/apply/users/tests/test_passkey_views.py
+++ b/hypha/apply/users/tests/test_passkey_views.py
@@ -706,19 +706,31 @@ class TestPasskeyElevationRequired(TestCase):
 
 
 @override_settings(RATELIMIT_ENABLE=False)
-class TestPasskeyElevationSkippedForOAuthUsers(TestCase):
-    """OAuth users have no usable password, so the elevation gate is skipped."""
+class TestPasskeyElevationRequiredForOAuthUsers(TestCase):
+    """OAuth users have no usable password, but must still elevate — the elevate
+    page routes them through the emailed confirmation-code flow.
+    """
 
     def setUp(self):
         self.user = OAuthUserFactory()  # no usable password
         self.client.force_login(self.user)
 
-    def test_register_begin_allowed_without_elevation(self):
+    def test_register_begin_requires_elevation(self):
         response = self.client.post(REGISTER_BEGIN_URL)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("challenge", response.json())
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("elevate_url", response.json())
+        self.assertIn(reverse("users:elevate"), response.json()["elevate_url"])
 
-    def test_delete_allowed_without_elevation(self):
+    def test_delete_requires_elevation_and_keeps_passkey(self):
+        passkey = make_passkey(self.user)
+        url = reverse("users:passkey_delete", args=[passkey.pk])
+        response = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(response.status_code, 204)
+        self.assertIn(reverse("users:elevate"), response["HX-Redirect"])
+        self.assertTrue(Passkey.objects.filter(pk=passkey.pk).exists())
+
+    def test_elevated_user_can_delete(self):
+        force_elevated(self)
         passkey = make_passkey(self.user)
         url = reverse("users:passkey_delete", args=[passkey.pk])
         response = self.client.post(url, HTTP_HX_REQUEST="true")

--- a/hypha/apply/users/tests/test_passkey_views.py
+++ b/hypha/apply/users/tests/test_passkey_views.py
@@ -7,11 +7,13 @@ from unittest.mock import MagicMock, patch
 from django.conf import settings
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from webauthn.helpers import bytes_to_base64url
 from webauthn.helpers.exceptions import InvalidAuthenticationResponse
 
 from ..models import Passkey
 from ..passkey_views import (
+    CHALLENGE_TTL_SECONDS,
     MAX_PASSKEYS_PER_USER,
     SESSION_CHALLENGE_KEY_AUTH,
     SESSION_CHALLENGE_KEY_REGISTER,
@@ -46,10 +48,13 @@ def make_passkey(
     )
 
 
-def set_challenge(client, key, challenge_bytes=b"test-challenge"):
-    """Store a base64-encoded WebAuthn challenge in the test client session."""
+def set_challenge(client, key, challenge_bytes=b"test-challenge", created=None):
+    """Store a WebAuthn challenge in the test client session."""
     session = client.session
-    session[key] = base64.b64encode(challenge_bytes).decode()
+    session[key] = {
+        "challenge": base64.b64encode(challenge_bytes).decode(),
+        "created": timezone.now().timestamp() if created is None else created,
+    }
     session.save()
 
 
@@ -169,6 +174,22 @@ class TestPasskeyRegisterComplete(TestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json())
+
+    def test_expired_challenge_returns_400(self):
+        # Challenge created well beyond the TTL is rejected.
+        set_challenge(
+            self.client,
+            SESSION_CHALLENGE_KEY_REGISTER,
+            self.CHALLENGE,
+            created=timezone.now().timestamp() - (CHALLENGE_TTL_SECONDS + 60),
+        )
+        response = self.client.post(
+            REGISTER_COMPLETE_URL,
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("challenge", response.json()["error"].lower())
 
     @patch("hypha.apply.users.passkey_views.verify_registration_response")
     def test_successful_registration_saves_passkey(self, mock_verify):

--- a/hypha/apply/users/tests/test_passkey_views.py
+++ b/hypha/apply/users/tests/test_passkey_views.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
+from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -208,6 +209,26 @@ class TestPasskeyRegisterComplete(TestCase):
         self.assertEqual(response.json()["status"], "ok")
         self.assertEqual(self.user.passkeys.count(), 1)
         self.assertEqual(self.user.passkeys.first().name, "My Key")
+
+    @override_settings(SEND_MESSAGES=True)
+    @patch("hypha.apply.users.passkey_views.verify_registration_response")
+    def test_successful_registration_sends_notification_email(self, mock_verify):
+        mock_verify.return_value = MagicMock(
+            credential_id=b"saved-cred-id",
+            credential_public_key=b"saved-pubkey",
+            sign_count=0,
+        )
+        self._set_challenge()
+        mail.outbox = []
+        self.client.post(
+            REGISTER_COMPLETE_URL,
+            data=json.dumps(self._payload(name="My Key")),
+            content_type="application/json",
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(self.user.email, mail.outbox[0].to)
+        self.assertIn("added", mail.outbox[0].subject.lower())
+        self.assertIn("My Key", mail.outbox[0].body)
 
     @patch("hypha.apply.users.passkey_views.verify_registration_response")
     def test_name_is_truncated_to_128_chars(self, mock_verify):
@@ -609,6 +630,17 @@ class TestPasskeyDelete(TestCase):
         url = reverse("users:passkey_delete", args=[passkey.pk])
         response = self.client.post(url)
         self.assertTemplateUsed(response, "users/partials/passkey-list.html")
+
+    @override_settings(SEND_MESSAGES=True)
+    def test_delete_sends_notification_email(self):
+        passkey = make_passkey(self.user, name="My Key")
+        url = reverse("users:passkey_delete", args=[passkey.pk])
+        mail.outbox = []
+        self.client.post(url)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(self.user.email, mail.outbox[0].to)
+        self.assertIn("removed", mail.outbox[0].subject.lower())
+        self.assertIn("My Key", mail.outbox[0].body)
 
 
 # ---------------------------------------------------------------------------

--- a/hypha/apply/users/tests/test_passkey_views.py
+++ b/hypha/apply/users/tests/test_passkey_views.py
@@ -16,7 +16,7 @@ from ..passkey_views import (
     SESSION_CHALLENGE_KEY_AUTH,
     SESSION_CHALLENGE_KEY_REGISTER,
 )
-from .factories import UserFactory
+from .factories import OAuthUserFactory, UserFactory
 
 AUTH_BEGIN_URL = reverse("users:passkey_auth_begin")
 AUTH_COMPLETE_URL = reverse("users:passkey_auth_complete")
@@ -53,6 +53,20 @@ def set_challenge(client, key, challenge_bytes=b"test-challenge"):
     session.save()
 
 
+def force_elevated(test_case):
+    """Treat the test client's session as recently re-authenticated (elevated).
+
+    Adding and deleting passkeys requires an elevated session; patch the
+    elevate middleware so gated views let the request through for the duration
+    of the test.
+    """
+    patcher = patch(
+        "hypha.elevate.middleware.has_elevated_privileges", return_value=True
+    )
+    patcher.start()
+    test_case.addCleanup(patcher.stop)
+
+
 # ---------------------------------------------------------------------------
 # Registration begin
 # ---------------------------------------------------------------------------
@@ -63,6 +77,7 @@ class TestPasskeyRegisterBegin(TestCase):
     def setUp(self):
         self.user = UserFactory()
         self.client.force_login(self.user)
+        force_elevated(self)
 
     def test_requires_login(self):
         self.client.logout()
@@ -107,6 +122,7 @@ class TestPasskeyRegisterComplete(TestCase):
     def setUp(self):
         self.user = UserFactory()
         self.client.force_login(self.user)
+        force_elevated(self)
 
     def _set_challenge(self):
         set_challenge(self.client, SESSION_CHALLENGE_KEY_REGISTER, self.CHALLENGE)
@@ -543,6 +559,7 @@ class TestPasskeyDelete(TestCase):
     def setUp(self):
         self.user = UserFactory()
         self.client.force_login(self.user)
+        force_elevated(self)
 
     def test_requires_login(self):
         self.client.logout()
@@ -634,6 +651,79 @@ class TestPasskeyRename(TestCase):
         url = reverse("users:passkey_rename", args=[passkey.pk])
         response = self.client.post(url, {"name": "Updated"})
         self.assertTemplateUsed(response, "users/partials/passkey-list.html")
+
+
+# ---------------------------------------------------------------------------
+# Elevation gate — adding and deleting passkeys requires a re-authenticated
+# (elevated) session, mirroring the 2FA-disable and email-change flows.
+# ---------------------------------------------------------------------------
+
+
+@override_settings(RATELIMIT_ENABLE=False)
+class TestPasskeyElevationRequired(TestCase):
+    """Users with a usable password must elevate before adding/removing passkeys."""
+
+    def setUp(self):
+        self.user = UserFactory()  # has a usable password
+        self.client.force_login(self.user)
+
+    def test_register_begin_requires_elevation(self):
+        response = self.client.post(REGISTER_BEGIN_URL)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("elevate_url", response.json())
+        self.assertIn(reverse("users:elevate"), response.json()["elevate_url"])
+
+    def test_register_begin_elevate_url_returns_to_account(self):
+        response = self.client.post(REGISTER_BEGIN_URL)
+        self.assertIn(reverse("users:account"), response.json()["elevate_url"])
+
+    def test_register_complete_requires_elevation(self):
+        set_challenge(self.client, SESSION_CHALLENGE_KEY_REGISTER)
+        response = self.client.post(
+            REGISTER_COMPLETE_URL,
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("elevate_url", response.json())
+
+    def test_delete_requires_elevation_and_keeps_passkey(self):
+        passkey = make_passkey(self.user)
+        url = reverse("users:passkey_delete", args=[passkey.pk])
+        # HTMX request — expect an HX-Redirect header instead of a JSON body.
+        response = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(response.status_code, 204)
+        self.assertIn(reverse("users:elevate"), response["HX-Redirect"])
+        self.assertTrue(Passkey.objects.filter(pk=passkey.pk).exists())
+
+    def test_elevated_user_can_delete(self):
+        force_elevated(self)
+        passkey = make_passkey(self.user)
+        url = reverse("users:passkey_delete", args=[passkey.pk])
+        response = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Passkey.objects.filter(pk=passkey.pk).exists())
+
+
+@override_settings(RATELIMIT_ENABLE=False)
+class TestPasskeyElevationSkippedForOAuthUsers(TestCase):
+    """OAuth users have no usable password, so the elevation gate is skipped."""
+
+    def setUp(self):
+        self.user = OAuthUserFactory()  # no usable password
+        self.client.force_login(self.user)
+
+    def test_register_begin_allowed_without_elevation(self):
+        response = self.client.post(REGISTER_BEGIN_URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("challenge", response.json())
+
+    def test_delete_allowed_without_elevation(self):
+        passkey = make_passkey(self.user)
+        url = reverse("users:passkey_delete", args=[passkey.pk])
+        response = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Passkey.objects.filter(pk=passkey.pk).exists())
 
 
 # ---------------------------------------------------------------------------

--- a/hypha/apply/users/tests/test_services.py
+++ b/hypha/apply/users/tests/test_services.py
@@ -4,7 +4,7 @@ from django.core import mail
 from django.test import RequestFactory, TestCase, override_settings
 
 from ..models import PendingSignup
-from ..services import PasswordlessAuthService
+from ..services import PasswordlessAuthService, send_passkey_notification
 from .factories import UserFactory
 
 
@@ -90,3 +90,42 @@ class TestPasswordlessAuthServiceInitiateLoginSignup(TestCase):
         service.initiate_login_signup(email=user.email)
 
         self.assertIn("/account/auth/", mail.outbox[0].body)
+
+
+@override_settings(SEND_MESSAGES=True)
+class TestSendPasskeyNotification(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = UserFactory()
+
+    def _request(self):
+        return self.factory.get("/")
+
+    def test_sends_email_when_added(self):
+        send_passkey_notification(self._request(), self.user, "My Key", added=True)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(self.user.email, mail.outbox[0].to)
+        self.assertIn("added", mail.outbox[0].subject.lower())
+        self.assertIn("My Key", mail.outbox[0].body)
+
+    def test_sends_email_when_removed(self):
+        send_passkey_notification(self._request(), self.user, "My Key", added=False)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(self.user.email, mail.outbox[0].to)
+        self.assertIn("removed", mail.outbox[0].subject.lower())
+        self.assertIn("My Key", mail.outbox[0].body)
+
+    def test_no_email_when_send_messages_disabled(self):
+        with self.settings(SEND_MESSAGES=False):
+            send_passkey_notification(self._request(), self.user, "My Key", added=True)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_no_email_when_user_has_no_email(self):
+        self.user.email = ""
+        self.user.save()
+        send_passkey_notification(self._request(), self.user, "My Key", added=True)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_works_without_request(self):
+        send_passkey_notification(None, self.user, "My Key", added=True)
+        self.assertEqual(len(mail.outbox), 1)

--- a/hypha/apply/users/utils.py
+++ b/hypha/apply/users/utils.py
@@ -8,6 +8,7 @@ from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import formats, timezone
 from django.utils.crypto import get_random_string
 from django.utils.encoding import force_bytes
 from django.utils.http import url_has_allowed_host_and_scheme, urlsafe_base64_encode
@@ -205,6 +206,31 @@ def get_zoneinfo(tz_name):
         return zoneinfo.ZoneInfo(tz_name)
     except (zoneinfo.ZoneInfoNotFoundError, KeyError):
         return None
+
+
+def local_event_time(request):
+    """Return a human-readable "now", localised to the user's timezone.
+
+    Shared by the account-security notification emails (login, passkey
+    added/removed) so the timestamp line reads the same across them.
+    """
+    tz_name = (
+        getattr(request, "session", {}).get("user_timezone", "") if request else ""
+    )
+    user_tz = get_zoneinfo(tz_name)
+    return "{} ({})".format(
+        formats.date_format(
+            timezone.localtime(timezone=user_tz), "SHORT_DATETIME_FORMAT"
+        ),
+        tz_name or timezone.get_current_timezone_name(),
+    )
+
+
+def passkeys_enabled() -> bool:
+    """Passkeys require WEBAUTHN_RP_ID in production. In DEBUG (local/dev)
+    we fall back to the request host so the feature can be exercised locally.
+    """
+    return bool(getattr(settings, "WEBAUTHN_RP_ID", None)) or settings.DEBUG
 
 
 def strip_html_and_nerf_urls(value: str):

--- a/hypha/core/context_processors.py
+++ b/hypha/core/context_processors.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from hypha.apply.users.passkey_views import passkeys_enabled
+from hypha.apply.users.utils import passkeys_enabled
 from hypha.home.models import ApplyHomePage
 
 

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -642,7 +642,7 @@ SECURE_REFERRER_POLICY = env.str(
 # https://django-elevate.readthedocs.io/en/latest/config/index.html
 # ------------------------------------------------------------------------------
 # How long should Elevate mode be active for?
-ELEVATE_COOKIE_AGE = env.int("ELEVATE_COOKIE_AGE", 3600)  # 1 hours
+ELEVATE_COOKIE_AGE = env.int("ELEVATE_COOKIE_AGE", 900)  # 15 minutes
 
 # An extra salt to be added into the cookie signature.
 ELEVATE_COOKIE_SALT = env.str("ELEVATE_COOKIE_SALT", SECRET_KEY)

--- a/hypha/static_src/javascript/passkeys.js
+++ b/hypha/static_src/javascript/passkeys.js
@@ -87,6 +87,12 @@ window.hypha.passkeys = (function () {
       const beginResp = await jsonPost(beginUrl, {});
       if (!beginResp.ok) {
         const err = await beginResp.json();
+        // The session must be elevated (re-authenticated) before adding a
+        // passkey — send the user to the elevate page and back.
+        if (err.elevate_url) {
+          window.location.href = err.elevate_url;
+          return;
+        }
         throw new Error(
           err.error || formEl?.dataset.errorServer || "Server error"
         );
@@ -105,6 +111,10 @@ window.hypha.passkeys = (function () {
       });
       if (!completeResp.ok) {
         const err = await completeResp.json();
+        if (err.elevate_url) {
+          window.location.href = err.elevate_url;
+          return;
+        }
         throw new Error(
           err.error || formEl?.dataset.errorRegister || "Registration failed"
         );


### PR DESCRIPTION
Also sending e-mail notifications when user add or delete a passkey. Made the default elevate cookie time 15 minuts instead of 60 minuts.

## Test Steps

 - [ ] Confirm that elevate privilege is requested when adding or deleting passkeys when more than 15 minuts passed since last authentication.
 - [ ] Confirm that adding and deleting passkeys works as before in other regard.
 - [ ] Check that e-mail notifications are sent when adding or deleting a passkey.