### PR TITLE
Load DJP plugin urls before Wagtails urls.

### DIFF
--- a/docs/references/plugins.md
+++ b/docs/references/plugins.md
@@ -7,3 +7,13 @@ See https://djp.readthedocs.io/ for more information.
 You can set the `DJP_PLUGINS_DIR` environment variable to point to a directory which contains *.py files implementing plugins. Good for development and when you do not want to publish the plugin on PyPI.
 
 Since DJP allow a plugin to override any setting you can tell Hypha to look for templates in a directory inside your plugin. This allows the plugin to override any template in Hypha.
+
+## URL ordering
+
+URLs contributed through the DJP `urlpatterns()` hook are added to the root urlconf **after** Hypha's own routes but **before** Wagtail's page-serving catch-all (`path("", include(wagtail_urls))`). This means:
+
+- A plugin **cannot** shadow a core Hypha URL (e.g. `apply/`, `admin/`, `account/`) — core routes are matched first.
+- A plugin URL **is** reachable even when it is slug-shaped (e.g. `account/country/`). Wagtail's catch-all would otherwise match any such path and return a 404 (*"The current path … matched the last one."*), so plugin URLs are deliberately placed ahead of it.
+- A plugin URL takes precedence over a Wagtail page at the same path.
+
+Prefer the `urlpatterns()` hook for adding routes. Only manipulate the root urlconf directly (e.g. from `AppConfig.ready()`) if you need finer control than the hook provides.

--- a/hypha/urls.py
+++ b/hypha/urls.py
@@ -108,12 +108,13 @@ urlpatterns += [
     ),
 ]
 
+# Load urls from any djp plugins.
+urlpatterns += djp.urlpatterns()
+
+# Need to be last.
 urlpatterns += [
     path("", include(wagtail_urls)),
 ]
-
-# Load urls from any djp plugins.
-urlpatterns += djp.urlpatterns()
 
 if settings.DEBUG:
     import debug_toolbar


### PR DESCRIPTION
Had some issues building a plugin and Wagtail documentation states that the wagtail urls should be loaded last.