### PR TITLE
Add account template hook for plugins to use

### DIFF
--- a/hypha/apply/users/templates/users/account.html
+++ b/hypha/apply/users/templates/users/account.html
@@ -1,5 +1,5 @@
 {% extends 'base-apply.html' %}
-{% load i18n users_tags wagtailcore_tags heroicons static %}
+{% load i18n users_tags wagtailcore_tags heroicons static hooks_tags %}
 
 {% block title %}{% trans "Account" %}{% endblock %}
 
@@ -54,6 +54,9 @@
                     {% trans "Save" %}
                 </button>
             </form>
+
+            {# Extension point for plugins to inject content into the profile column. #}
+            {% hook "user_account_profile" %}
         </div>
 
         <div class="flex-1 md:ps-8">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hypha"
 description = "A open source submission management platform to receive and manage applications for funding."
 readme = "README.md"
-version = "6.5.0"
+version = "6.6.0"
 requires-python = ">=3.10"
 license = "BSD-3-Clause"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1878,7 +1878,7 @@ wheels = [
 
 [[package]]
 name = "hypha"
-version = "6.5.0"
+version = "6.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
Also bump Hypha version to 6.6.0 in preparation for new release.

This template hook allows plugin to easily add fields etc. to the account page.