### PR TITLE
Pin rustywind version to 0.24.3. Later version sort classes differently.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         name: rustywind Tailwind CSS class linter
         language: node
         additional_dependencies:
-          - rustywind@latest
+          - rustywind@0.24.3
         entry: rustywind
         args: [--write]
         types_or: [html, css]


### PR DESCRIPTION
Fixes #4927